### PR TITLE
Remove node version specification in workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
-        with:
-          node-version: 22
       - run: npm ci
       - run: npx playwright install --with-deps
       - run: npm run build --if-present
@@ -29,7 +27,6 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
       - run: npm ci


### PR DESCRIPTION
Removed specific node version settings from the npm-publish workflow.