### PR TITLE
Fix null element check in document-title rule

### DIFF
--- a/src/rules/document-title.ts
+++ b/src/rules/document-title.ts
@@ -5,6 +5,9 @@ const text = "Documents must have <title> element to aid in navigation";
 const url = `https://dequeuniversity.com/rules/axe/4.11/${id}`;
 
 export default function (element: Element): AccessibilityError[] {
+  if (!element) {
+    return [];
+  }
   const document = element.ownerDocument;
   if (!document) {
     return [];


### PR DESCRIPTION
## Summary
- Add null guard for `element` parameter before accessing `ownerDocument` in the document-title rule
- Fixes TypeError in iframe-based test environments where the element may not be available
- This was causing CI failures on other PRs (#221)

## Test plan
- [x] All 107 test files pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)