### PR TITLE
Remove debug console.log from aria-valid-attr-value

### DIFF
--- a/src/rules/aria-valid-attr-value.ts
+++ b/src/rules/aria-valid-attr-value.ts
@@ -26,13 +26,6 @@ function valid(element: Element, attribute: string, info: Info) {
   } else if (info.type === "idref") {
     if (info.allowEmpty && value === "") return true;
     const referencedValue = document.querySelector<HTMLElement>(`#${value}`);
-    if (element.id === "pass169")
-      console.log(
-        element.id,
-        value,
-        referencedValue,
-        document.querySelectorAll("div"),
-      );
     if (!referencedValue) return false;
     if (
       referencedValue.hasAttribute("hidden") ||


### PR DESCRIPTION
## Summary
- Removes leftover debug `console.log` statement in `src/rules/aria-valid-attr-value.ts` that was gated behind `element.id === "pass169"`

Closes #291

## Test plan
- `npm run lint:types` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)