### PR TITLE
Complete validAriaAttributesWithRole mappings for all role-specific ARIA attributes

### DIFF
--- a/src/rules/aria-valid-attr.ts
+++ b/src/rules/aria-valid-attr.ts
@@ -17,11 +17,10 @@ export default function (element_: Element): AccessibilityError[] {
   const elements = querySelectorAll(selector, element_);
   for (const element of [element_, ...elements]) {
     for (const attribute of element.attributes) {
+      const roleRestricted = validAriaAttributesWithRole[attribute.name];
       if (
-        attribute.name === "aria-errormessage" &&
-        validAriaAttributesWithRole["aria-errormessage"].includes(
-          element.getAttribute("role") || "",
-        )
+        roleRestricted &&
+        roleRestricted.includes(element.getAttribute("role") || "")
       ) {
         continue;
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -279,18 +279,73 @@ export const validAriaAttributes = [
   "aria-valuetext",
 ];
 
-export const validAriaAttributesWithRole = {
+export const validAriaAttributesWithRole: Record<string, string[]> = {
+  "aria-activedescendant": [
+    "combobox", "grid", "listbox", "menu", "menubar", "radiogroup", "tablist",
+    "tree", "treegrid", "application", "group",
+  ],
+  "aria-autocomplete": ["combobox", "textbox", "searchbox"],
+  "aria-checked": [
+    "checkbox", "menuitemcheckbox", "menuitemradio", "option", "radio", "switch",
+  ],
+  "aria-colcount": ["grid", "table", "treegrid"],
+  "aria-colindex": ["cell", "columnheader", "gridcell", "row", "rowheader"],
+  "aria-colspan": ["cell", "columnheader", "gridcell", "rowheader"],
   "aria-errormessage": [
-    "alert",
-    "application",
-    "banner",
-    "checkbox",
-    "contentinfo",
-    "doc-appendix",
-    "doc-glossary",
-    "group",
-    "log",
-    "menubar",
-    "scrollbar",
+    "alert", "application", "banner", "checkbox", "contentinfo",
+    "doc-appendix", "doc-glossary", "group", "log", "menubar", "scrollbar",
+  ],
+  "aria-expanded": [
+    "application", "button", "checkbox", "combobox", "gridcell", "link",
+    "listbox", "menuitem", "row", "rowheader", "tab", "treeitem",
+    "columnheader", "menuitemcheckbox", "menuitemradio",
+  ],
+  "aria-level": ["heading", "listitem", "row", "tablist", "treeitem", "comment"],
+  "aria-modal": ["alertdialog", "dialog"],
+  "aria-multiline": ["textbox", "searchbox"],
+  "aria-multiselectable": ["grid", "listbox", "tablist", "tree", "treegrid"],
+  "aria-orientation": [
+    "listbox", "menu", "menubar", "radiogroup", "scrollbar", "select",
+    "separator", "slider", "tablist", "toolbar", "tree", "treegrid", "combobox",
+  ],
+  "aria-placeholder": ["textbox", "searchbox"],
+  "aria-posinset": [
+    "article", "comment", "listitem", "menuitem", "menuitemcheckbox",
+    "menuitemradio", "option", "radio", "row", "tab", "treeitem",
+  ],
+  "aria-pressed": ["button"],
+  "aria-readonly": [
+    "checkbox", "combobox", "grid", "gridcell", "listbox", "radiogroup",
+    "slider", "spinbutton", "textbox", "treegrid", "columnheader", "rowheader",
+    "searchbox", "menuitemcheckbox", "menuitemradio",
+  ],
+  "aria-required": [
+    "checkbox", "combobox", "gridcell", "listbox", "radiogroup", "spinbutton",
+    "textbox", "tree", "columnheader", "rowheader", "searchbox", "select",
+    "treegrid",
+  ],
+  "aria-rowcount": ["grid", "table", "treegrid"],
+  "aria-rowindex": ["cell", "row", "columnheader", "gridcell", "rowheader"],
+  "aria-rowspan": ["cell", "columnheader", "gridcell", "rowheader"],
+  "aria-selected": [
+    "cell", "columnheader", "gridcell", "option", "row", "rowheader", "tab",
+    "treeitem",
+  ],
+  "aria-setsize": [
+    "article", "comment", "listitem", "menuitem", "menuitemcheckbox",
+    "menuitemradio", "option", "radio", "row", "tab", "treeitem",
+  ],
+  "aria-sort": ["columnheader", "rowheader"],
+  "aria-valuemax": [
+    "meter", "progressbar", "scrollbar", "separator", "slider", "spinbutton",
+  ],
+  "aria-valuemin": [
+    "meter", "progressbar", "scrollbar", "separator", "slider", "spinbutton",
+  ],
+  "aria-valuenow": [
+    "meter", "progressbar", "scrollbar", "separator", "slider", "spinbutton",
+  ],
+  "aria-valuetext": [
+    "meter", "progressbar", "scrollbar", "separator", "slider", "spinbutton",
   ],
 };


### PR DESCRIPTION
## Summary
- Expands `validAriaAttributesWithRole` in `src/utils.ts` from 1 entry (`aria-errormessage`) to 27 entries covering all role-specific ARIA attributes per the WAI-ARIA spec
- Generalizes the role check in `src/rules/aria-valid-attr.ts` to work with any attribute in the map, instead of only hardcoding `aria-errormessage`

Fixes #301

## Test plan
- [x] All 140 existing tests pass
- [ ] Verify role-specific ARIA attributes are correctly validated against allowed roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)