### PR TITLE
Add stale test cleanup to ACT test generator

### DIFF
--- a/generate-act-tests.js
+++ b/generate-act-tests.js
@@ -1,4 +1,8 @@
-import { mkdir, writeFile, readFile } from "node:fs/promises";
+import { mkdir, writeFile, readFile, rm } from "node:fs/promises";
+
+// Clean up previously generated test files to remove stale tests
+// when rules are added to the ignore list or test cases are removed.
+await rm("./tests/act/tests/", { recursive: true, force: true });
 
 const { testcases } = JSON.parse(await readFile("./testcases.json", "utf8"));
 


### PR DESCRIPTION
Closes #326

## Summary
- Adds `rm("./tests/act/tests/", { recursive: true, force: true })` at the start of `generate-act-tests.js`
- Ensures orphaned test files from removed test cases or newly ignored rules are cleaned up before regeneration

## Test plan
- [x] Verified script still generates tests correctly after adding cleanup step

🤖 Generated with [Claude Code](https://claude.com/claude-code)