### PR TITLE
Implement summary-name rule (ACT rule 2t702h)

### DIFF
--- a/src/rules/summary-name.ts
+++ b/src/rules/summary-name.ts
@@ -1,0 +1,34 @@
+import { AccessibilityError } from "../scanner";
+import { querySelectorAll, labelledByIsValid } from "../utils";
+
+const id = "summary-name";
+const text = "Summary elements must have discernible text";
+const url = `https://dequeuniversity.com/rules/axe/4.11/${id}`;
+
+export default function (element: Element): AccessibilityError[] {
+  const errors = [];
+  const details = querySelectorAll("details", element);
+  if (element.matches("details")) {
+    details.push(element as HTMLElement);
+  }
+
+  for (const detail of details) {
+    // Only check the first <summary> child of each <details>
+    const summary = detail.querySelector(":scope > summary");
+    if (!summary) continue;
+
+    if (summary.textContent?.trim() !== "") continue;
+    if (summary.getAttribute("aria-label")?.trim()) continue;
+    if (labelledByIsValid(summary)) continue;
+    if ((summary as HTMLElement).title?.trim()) continue;
+
+    errors.push({
+      id,
+      element: summary,
+      text,
+      url,
+    });
+  }
+
+  return errors;
+}

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -70,6 +70,7 @@ import emptyTableHeader from "./rules/empty-table-header";
 import cssOrientationLock from "./rules/css-orientation-lock";
 import autocompleteValid from "./rules/autocomplete-valid";
 import avoidInlineSpacing from "./rules/avoid-inline-spacing";
+import summaryName from "./rules/summary-name";
 import svgImgAlt from "./rules/svg-img-alt";
 import focusOrderSemantics from "./rules/focus-order-semantics";
 import audioCaptions from "./rules/audio-caption";
@@ -195,6 +196,7 @@ export const allRules: Rule[] = [
   selectName,
   serverSideImageMap,
   skipLink,
+  summaryName,
   svgImgAlt,
   tabindex,
   tableDuplicateName,

--- a/tests/act/tests/2t702h/a7fd233a404e737baaee10e34c35e40bbe7f14bb.ts
+++ b/tests/act/tests/2t702h/a7fd233a404e737baaee10e34c35e40bbe7f14bb.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[2t702h]Summary element has non-empty accessible name", function () {
-  it.skip("Failed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2t702h/a7fd233a404e737baaee10e34c35e40bbe7f14bb.html)", async () => {
+  it("Failed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2t702h/a7fd233a404e737baaee10e34c35e40bbe7f14bb.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html lang="en">
 <head>

--- a/tests/act/tests/2t702h/f0f5f9e727e46e257e5d6420a8ab11b760c75617.ts
+++ b/tests/act/tests/2t702h/f0f5f9e727e46e257e5d6420a8ab11b760c75617.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[2t702h]Summary element has non-empty accessible name", function () {
-  it.skip("Failed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2t702h/f0f5f9e727e46e257e5d6420a8ab11b760c75617.html)", async () => {
+  it("Failed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2t702h/f0f5f9e727e46e257e5d6420a8ab11b760c75617.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html lang="en">
 <head>

--- a/tests/act/tests/2t702h/f76f484c92eec764dbd1ee3e5ee3421f230a56d7.ts
+++ b/tests/act/tests/2t702h/f76f484c92eec764dbd1ee3e5ee3421f230a56d7.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[2t702h]Summary element has non-empty accessible name", function () {
-  it.skip("Failed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2t702h/f76f484c92eec764dbd1ee3e5ee3421f230a56d7.html)", async () => {
+  it("Failed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2t702h/f76f484c92eec764dbd1ee3e5ee3421f230a56d7.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Summary
- New rule `summary-name` checks that `<summary>` elements have non-empty accessible names
- Checks the first `<summary>` child of each `<details>` element
- Accessible name sources: textContent, aria-label, aria-labelledby, title
- Registered in scanner.ts
- Unskips 3 ACT tests

Closes #333

## Test plan
- [x] All 8 ACT tests in `2t702h/` pass (3 previously skipped, 5 existing)
- [x] Empty summary → violation reported
- [x] Summary with `role="none"` → violation reported
- [x] First empty summary with second having text → violation reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)