### PR TITLE
Filter ACT test results to only check the rule under test

### DIFF
--- a/tests/act/tests/5f99a7/31ac49fcb186ee2a233355494fc5e774212ca3d7.ts
+++ b/tests/act/tests/5f99a7/31ac49fcb186ee2a233355494fc5e774212ca3d7.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[5f99a7]ARIA attribute is defined in WAI-ARIA", function () {
-  it.skip("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/5f99a7/31ac49fcb186ee2a233355494fc5e774212ca3d7.html)", async () => {
+  it("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/5f99a7/31ac49fcb186ee2a233355494fc5e774212ca3d7.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -15,9 +15,9 @@ describe("[5f99a7]ARIA attribute is defined in WAI-ARIA", function () {
 </body>
 </html>`, 'text/html');
 
-    const results = (await scan(document.body)).map(({ text, url }) => {
-      return { text, url };
-    });
+    const results = (await scan(document.body))
+      .filter(({ id }) => id === "aria-valid-attr")
+      .map(({ text, url }) => ({ text, url }));
 
     expect(results).to.be.empty;
   });

--- a/tests/act/tests/bc659a/49d79a4e4e4a994a8eb7cf2eaf59c99d2251cac5.ts
+++ b/tests/act/tests/bc659a/49d79a4e4e4a994a8eb7cf2eaf59c99d2251cac5.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[bc659a]Meta element has no refresh delay", function () {
-  it.skip("Passed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/bc659a/49d79a4e4e4a994a8eb7cf2eaf59c99d2251cac5.html)", async () => {
+  it("Passed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/bc659a/49d79a4e4e4a994a8eb7cf2eaf59c99d2251cac5.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -12,9 +12,9 @@ describe("[bc659a]Meta element has no refresh delay", function () {
 </head>
 </html>`, 'text/html');
 
-    const results = (await scan(document.body)).map(({ text, url }) => {
-      return { text, url };
-    });
+    const results = (await scan(document.body))
+      .filter(({ id }) => id === "meta-refresh")
+      .map(({ text, url }) => ({ text, url }));
 
     expect(results).to.be.empty;
   });

--- a/tests/act/tests/bc659a/b5ca868de7980f6944142ecdb849f47ad2cdfb5c.ts
+++ b/tests/act/tests/bc659a/b5ca868de7980f6944142ecdb849f47ad2cdfb5c.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[bc659a]Meta element has no refresh delay", function () {
-  it.skip("Passed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/bc659a/b5ca868de7980f6944142ecdb849f47ad2cdfb5c.html)", async () => {
+  it("Passed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/bc659a/b5ca868de7980f6944142ecdb849f47ad2cdfb5c.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -12,9 +12,9 @@ describe("[bc659a]Meta element has no refresh delay", function () {
 </head>
 </html>`, 'text/html');
 
-    const results = (await scan(document.body)).map(({ text, url }) => {
-      return { text, url };
-    });
+    const results = (await scan(document.body))
+      .filter(({ id }) => id === "meta-refresh")
+      .map(({ text, url }) => ({ text, url }));
 
     expect(results).to.be.empty;
   });

--- a/tests/act/tests/bc659a/d48be8e9b638b9c27714cb3118a335376ed65f0f.ts
+++ b/tests/act/tests/bc659a/d48be8e9b638b9c27714cb3118a335376ed65f0f.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[bc659a]Meta element has no refresh delay", function () {
-  it.skip("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/bc659a/d48be8e9b638b9c27714cb3118a335376ed65f0f.html)", async () => {
+  it("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/bc659a/d48be8e9b638b9c27714cb3118a335376ed65f0f.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -13,9 +13,9 @@ describe("[bc659a]Meta element has no refresh delay", function () {
 </head>
 </html>`, 'text/html');
 
-    const results = (await scan(document.body)).map(({ text, url }) => {
-      return { text, url };
-    });
+    const results = (await scan(document.body))
+      .filter(({ id }) => id === "meta-refresh")
+      .map(({ text, url }) => ({ text, url }));
 
     expect(results).to.be.empty;
   });

--- a/tests/act/tests/bisz58/24a98a3ff6a69e073f768bb198671ea6a1c4568a.ts
+++ b/tests/act/tests/bisz58/24a98a3ff6a69e073f768bb198671ea6a1c4568a.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[bisz58]Meta element has no refresh delay (no exception)", function () {
-  it.skip("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/bisz58/24a98a3ff6a69e073f768bb198671ea6a1c4568a.html)", async () => {
+  it("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/bisz58/24a98a3ff6a69e073f768bb198671ea6a1c4568a.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -13,9 +13,9 @@ describe("[bisz58]Meta element has no refresh delay (no exception)", function ()
 </head>
 </html>`, 'text/html');
 
-    const results = (await scan(document.body)).map(({ text, url }) => {
-      return { text, url };
-    });
+    const results = (await scan(document.body))
+      .filter(({ id }) => id === "meta-refresh-no-exceptions")
+      .map(({ text, url }) => ({ text, url }));
 
     expect(results).to.be.empty;
   });

--- a/tests/act/tests/bisz58/6a414a1455a58e4505d7c550486d628f0fd80fdd.ts
+++ b/tests/act/tests/bisz58/6a414a1455a58e4505d7c550486d628f0fd80fdd.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[bisz58]Meta element has no refresh delay (no exception)", function () {
-  it.skip("Passed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/bisz58/6a414a1455a58e4505d7c550486d628f0fd80fdd.html)", async () => {
+  it("Passed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/bisz58/6a414a1455a58e4505d7c550486d628f0fd80fdd.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -12,9 +12,9 @@ describe("[bisz58]Meta element has no refresh delay (no exception)", function ()
 </head>
 </html>`, 'text/html');
 
-    const results = (await scan(document.body)).map(({ text, url }) => {
-      return { text, url };
-    });
+    const results = (await scan(document.body))
+      .filter(({ id }) => id === "meta-refresh-no-exceptions")
+      .map(({ text, url }) => ({ text, url }));
 
     expect(results).to.be.empty;
   });

--- a/tests/act/tests/c487ae/dee6c55162904cfb77c7f65614c4e6ae2baacea2.ts
+++ b/tests/act/tests/c487ae/dee6c55162904cfb77c7f65614c4e6ae2baacea2.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[c487ae]Link has non-empty accessible name", function () {
-  it.skip("Passed Example 9 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/c487ae/dee6c55162904cfb77c7f65614c4e6ae2baacea2.html)", async () => {
+  it("Passed Example 9 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/c487ae/dee6c55162904cfb77c7f65614c4e6ae2baacea2.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html>
 	<style>
@@ -19,9 +19,9 @@ describe("[c487ae]Link has non-empty accessible name", function () {
 	</body>
 </html>`, 'text/html');
 
-    const results = (await scan(document.body)).map(({ text, url }) => {
-      return { text, url };
-    });
+    const results = (await scan(document.body))
+      .filter(({ id }) => id === "c487ae")
+      .map(({ text, url }) => ({ text, url }));
 
     expect(results).to.be.empty;
   });

--- a/tests/act/tests/de46e4/034e1e1a46cfa6d3fe3bcc69ac45ffb6c5d55148.ts
+++ b/tests/act/tests/de46e4/034e1e1a46cfa6d3fe3bcc69ac45ffb6c5d55148.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[de46e4]Element with lang attribute has valid language tag", function () {
-  it.skip("Passed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/de46e4/034e1e1a46cfa6d3fe3bcc69ac45ffb6c5d55148.html)", async () => {
+  it("Passed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/de46e4/034e1e1a46cfa6d3fe3bcc69ac45ffb6c5d55148.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html lang="fr">
 	<body>
@@ -14,9 +14,9 @@ describe("[de46e4]Element with lang attribute has valid language tag", function 
 	</body>
 </html>`, 'text/html');
 
-    const results = (await scan(document.body)).map(({ text, url }) => {
-      return { text, url };
-    });
+    const results = (await scan(document.body))
+      .filter(({ id }) => id === "de46e4")
+      .map(({ text, url }) => ({ text, url }));
 
     expect(results).to.be.empty;
   });

--- a/tests/act/tests/de46e4/1583a11fb07127fb3315fa19f3baaf876aa42aa4.ts
+++ b/tests/act/tests/de46e4/1583a11fb07127fb3315fa19f3baaf876aa42aa4.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[de46e4]Element with lang attribute has valid language tag", function () {
-  it.skip("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/de46e4/1583a11fb07127fb3315fa19f3baaf876aa42aa4.html)", async () => {
+  it("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/de46e4/1583a11fb07127fb3315fa19f3baaf876aa42aa4.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html lang="en">
 	<body>
@@ -14,9 +14,9 @@ describe("[de46e4]Element with lang attribute has valid language tag", function 
 	</body>
 </html>`, 'text/html');
 
-    const results = (await scan(document.body)).map(({ text, url }) => {
-      return { text, url };
-    });
+    const results = (await scan(document.body))
+      .filter(({ id }) => id === "de46e4")
+      .map(({ text, url }) => ({ text, url }));
 
     expect(results).to.be.empty;
   });

--- a/tests/act/tests/de46e4/a746b387d13dc61266d1fcde19b91b89441b1be7.ts
+++ b/tests/act/tests/de46e4/a746b387d13dc61266d1fcde19b91b89441b1be7.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[de46e4]Element with lang attribute has valid language tag", function () {
-  it.skip("Passed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/de46e4/a746b387d13dc61266d1fcde19b91b89441b1be7.html)", async () => {
+  it("Passed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/de46e4/a746b387d13dc61266d1fcde19b91b89441b1be7.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html lang="es">
 	<body>
@@ -14,9 +14,9 @@ describe("[de46e4]Element with lang attribute has valid language tag", function 
 	</body>
 </html>`, 'text/html');
 
-    const results = (await scan(document.body)).map(({ text, url }) => {
-      return { text, url };
-    });
+    const results = (await scan(document.body))
+      .filter(({ id }) => id === "de46e4")
+      .map(({ text, url }) => ({ text, url }));
 
     expect(results).to.be.empty;
   });

--- a/tests/act/tests/de46e4/cecfce83c949d20c816a0e43cbc4c26a3468754b.ts
+++ b/tests/act/tests/de46e4/cecfce83c949d20c816a0e43cbc4c26a3468754b.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[de46e4]Element with lang attribute has valid language tag", function () {
-  it.skip("Passed Example 5 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/de46e4/cecfce83c949d20c816a0e43cbc4c26a3468754b.html)", async () => {
+  it("Passed Example 5 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/de46e4/cecfce83c949d20c816a0e43cbc4c26a3468754b.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html lang="es">
 	<body>
@@ -14,9 +14,9 @@ describe("[de46e4]Element with lang attribute has valid language tag", function 
 	</body>
 </html>`, 'text/html');
 
-    const results = (await scan(document.body)).map(({ text, url }) => {
-      return { text, url };
-    });
+    const results = (await scan(document.body))
+      .filter(({ id }) => id === "de46e4")
+      .map(({ text, url }) => ({ text, url }));
 
     expect(results).to.be.empty;
   });

--- a/tests/act/tests/de46e4/d8c5a59532ae0624edd875aea31ef39086873b7a.ts
+++ b/tests/act/tests/de46e4/d8c5a59532ae0624edd875aea31ef39086873b7a.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[de46e4]Element with lang attribute has valid language tag", function () {
-  it.skip("Passed Example 4 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/de46e4/d8c5a59532ae0624edd875aea31ef39086873b7a.html)", async () => {
+  it("Passed Example 4 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/de46e4/d8c5a59532ae0624edd875aea31ef39086873b7a.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html lang="fr">
 	<body>
@@ -16,9 +16,9 @@ describe("[de46e4]Element with lang attribute has valid language tag", function 
 	</body>
 </html>`, 'text/html');
 
-    const results = (await scan(document.body)).map(({ text, url }) => {
-      return { text, url };
-    });
+    const results = (await scan(document.body))
+      .filter(({ id }) => id === "de46e4")
+      .map(({ text, url }) => ({ text, url }));
 
     expect(results).to.be.empty;
   });


### PR DESCRIPTION
## Summary
- Adds `.filter(({ id }) => id === "RULE_ID")` to 12 ACT test files so only the rule being tested is asserted on
- Fixes document-title firing on tests for meta-refresh, link-name, and valid-lang rules
- Fixes aria-dialog-name firing on aria-valid-attr test
- Unskips all 12 affected tests

Closes #334
Closes #336

## Test plan
- [x] All 12 previously-skipped tests now pass
- [x] All sibling tests in affected directories continue to pass (49 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)