### PR TITLE
Enable ACT tests for html-xml-lang-mismatch (5b7ae0)

### DIFF
--- a/generate-act-tests.js
+++ b/generate-act-tests.js
@@ -162,7 +162,6 @@ const rulesToIgnore = [
 
   // --- Unknown or deprecated ACT rules ---
   "3ea0c8", // Unknown ACT rule - not in current testcases
-  "5b7ae0", // Unknown ACT rule - not in current testcases
   "e6952f", // Unknown ACT rule - not in current testcases
 ];
 


### PR DESCRIPTION
## Summary
- Removed `5b7ae0` from `rulesToIgnore` in `generate-act-tests.js`
- The W3C testcases.json doesn't currently include test cases for this rule, so no new test files are generated yet — but the rule is implemented and unit-tested
- When W3C adds test cases, they'll be picked up automatically

Fixes #343

## Test plan
- [x] All 172 existing tests pass
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)