### PR TITLE
Enable ACT tests for no-autoplay-audio rule (80f0bf)

### DIFF
--- a/generate-act-tests.js
+++ b/generate-act-tests.js
@@ -88,7 +88,6 @@ const rulesToIgnore = [
   "1ea59c", // Video element visual content has audio description - requires media playback
   "1ec09b", // Video element visual content has strict accessible alternative - requires media playback
   "4c31df", // Audio or video element that plays automatically has a control mechanism - requires media playback
-  "80f0bf", // Audio or video element avoids automatically playing audio - requires media playback
   "aaa1bf", // Audio or video element that plays automatically has no audio that lasts more than 3 seconds - requires media playback
   "c3232f", // Video element visual-only content has accessible alternative - requires media playback
   "c5a4ea", // Video element visual content has accessible alternative - requires media playback
@@ -217,6 +216,12 @@ const skippedExamples = [
 
   // [e88epe] decorative-image: scanner does not analyse canvas visual content
   "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e88epe/6d108d00cc7a54f66547f02d7e7606342b11f801.html",
+
+  // [80f0bf] no-autoplay-audio: scanner can't detect short media duration from URL fragment (#t=8,10)
+  "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/80f0bf/e4d78b5074773ab0cbd8c72732e948c4608f5c9d.html",
+
+  // [80f0bf] no-autoplay-audio: scanner can't detect JavaScript-based control mechanisms
+  "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/80f0bf/29ea904ef03f14401a7b43a5ffc9b30271697bc7.html",
 
   // [de46e4] valid-lang: scanner doesn't detect invalid lang subtags on non-root elements
   "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/de46e4/49b66676ed867c75368e31c1e06b28255df8089e.html",

--- a/tests/act/tests/80f0bf/0d2dcde8931a9083e590034768ae2e0af747491c.ts
+++ b/tests/act/tests/80f0bf/0d2dcde8931a9083e590034768ae2e0af747491c.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[80f0bf]Audio or video element avoids automatically playing audio", function () {
+  it("Passed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/80f0bf/0d2dcde8931a9083e590034768ae2e0af747491c.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 1</title>
+</head>
+<body>
+	<audio src="/WAI/content-assets/wcag-act-rules/test-assets/moon-audio/moon-speech.mp3" autoplay controls></audio>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/no-autoplay-audio"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/80f0bf/29ea904ef03f14401a7b43a5ffc9b30271697bc7.ts
+++ b/tests/act/tests/80f0bf/29ea904ef03f14401a7b43a5ffc9b30271697bc7.ts
@@ -1,0 +1,48 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[80f0bf]Audio or video element avoids automatically playing audio", function () {
+  it.skip("Passed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/80f0bf/29ea904ef03f14401a7b43a5ffc9b30271697bc7.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<style>
+		button {
+			color: #000;
+		}
+		button:hover {
+			cursor: pointer;
+			cursor: pointer;
+			background-color: grey;
+			color: white;
+		}
+	</style>
+</head>
+<body>
+	<div id="video-container">
+		<!-- Video -->
+		<video id="video" autoplay>
+			<source src="/WAI/content-assets/wcag-act-rules/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+			<source src="/WAI/content-assets/wcag-act-rules/test-assets/rabbit-video/video.webm" type="video/webm" />
+		</video>
+		<!-- Video Controls -->
+		<div id="video-controls">
+			<button type="button" id="play-pause" class="play">Play</button>
+			<button type="button" id="mute">Mute</button>
+		</div>
+	</div>
+	<script src="/WAI/content-assets/wcag-act-rules/test-assets/80f0bf/no-autoplay.js"></script>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/no-autoplay-audio"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/80f0bf/968b12b14eb008b424f050ab74277426b2ea81bf.ts
+++ b/tests/act/tests/80f0bf/968b12b14eb008b424f050ab74277426b2ea81bf.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[80f0bf]Audio or video element avoids automatically playing audio", function () {
+  it("Failed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/80f0bf/968b12b14eb008b424f050ab74277426b2ea81bf.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 1</title>
+</head>
+<body>
+	<audio src="/WAI/content-assets/wcag-act-rules/test-assets/moon-audio/moon-speech.mp3" autoplay></audio>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/no-autoplay-audio"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/80f0bf/b712209d068fff2878cceadf40efe21a3ec4f6d8.ts
+++ b/tests/act/tests/80f0bf/b712209d068fff2878cceadf40efe21a3ec4f6d8.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[80f0bf]Audio or video element avoids automatically playing audio", function () {
+  it("Failed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/80f0bf/b712209d068fff2878cceadf40efe21a3ec4f6d8.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 2</title>
+</head>
+<body>
+	<video autoplay>
+		<source src="/WAI/content-assets/wcag-act-rules/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+		<source src="/WAI/content-assets/wcag-act-rules/test-assets/rabbit-video/video.webm" type="video/webm" />
+	</video>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/no-autoplay-audio"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/80f0bf/e4d78b5074773ab0cbd8c72732e948c4608f5c9d.ts
+++ b/tests/act/tests/80f0bf/e4d78b5074773ab0cbd8c72732e948c4608f5c9d.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[80f0bf]Audio or video element avoids automatically playing audio", function () {
+  it.skip("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/80f0bf/e4d78b5074773ab0cbd8c72732e948c4608f5c9d.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 2</title>
+</head>
+<body>
+	<video autoplay>
+		<source src="/WAI/content-assets/wcag-act-rules/test-assets/rabbit-video/video.mp4#t=8,10" type="video/mp4" />
+		<source src="/WAI/content-assets/wcag-act-rules/test-assets/rabbit-video/video.webm#t=8,10" type="video/webm" />
+	</video>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/no-autoplay-audio"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});


### PR DESCRIPTION
## Summary
- Removed `80f0bf` from `rulesToIgnore` in `generate-act-tests.js` to enable ACT test coverage for the `no-autoplay-audio` rule
- 3 of 5 non-inapplicable tests pass out of the box (Passed Example 1 with `controls` attribute, Failed Examples 1 and 2 for autoplay without controls)
- Skipped 2 tests that require capabilities beyond static DOM analysis:
  - **Passed Example 2**: Video with short duration via URL fragment (`#t=8,10`) -- scanner can't detect media duration
  - **Passed Example 3**: Video with JavaScript-based play/mute buttons -- scanner can't detect JS control mechanisms
- Updated README via `build:readme`

## Test plan
- [x] `npm run format` passes
- [x] `npm test` passes (246 test files, 0 failures)
- [x] `npm run build:readme` run to update docs

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)