### PR TITLE
Implement label-content-name-mismatch rule (ACT 2ee8b8)

### DIFF
--- a/generate-act-tests.js
+++ b/generate-act-tests.js
@@ -140,7 +140,6 @@ const rulesToIgnore = [
   "3e12e1", // Block of repeated content is collapsible - not implemented
 
   // --- Not implemented - various other rules ---
-  "2ee8b8", // Visible label is part of accessible name - not implemented
   "73f2c2", // Autocomplete attribute has valid value - not implemented in ACT test format
   "b4f0c3", // Meta viewport allows for zoom - not implemented in ACT test format
   "4b1c6c", // Iframe elements with identical accessible names have equivalent purpose - not implemented
@@ -222,6 +221,9 @@ const skippedExamples = [
 
   // [80f0bf] no-autoplay-audio: scanner can't detect JavaScript-based control mechanisms
   "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/80f0bf/29ea904ef03f14401a7b43a5ffc9b30271697bc7.html",
+
+  // [2ee8b8] label-content-name-mismatch: scanner cannot detect icon fonts (requires CSS rendering)
+  "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2ee8b8/efa9543339cdad5412c7719b266a633a29ce149e.html",
 
   // [de46e4] valid-lang: scanner doesn't detect invalid lang subtags on non-root elements
   "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/de46e4/49b66676ed867c75368e31c1e06b28255df8089e.html",

--- a/rules.json
+++ b/rules.json
@@ -973,7 +973,7 @@
         "ACT Rules": ""
       },
       {
-        "implemented": "❌",
+        "implemented": "✅",
         "id": "label-content-name-mismatch",
         "url": "https://dequeuniversity.com/rules/axe/4.11/label-content-name-mismatch?application=RuleDescription",
         "Description": "Ensures that elements labelled through their content must have their visible text as part of their accessible name",

--- a/src/rules/label-content-name-mismatch.ts
+++ b/src/rules/label-content-name-mismatch.ts
@@ -7,33 +7,100 @@ const text =
 const url = `https://dequeuniversity.com/rules/axe/4.11/${id}`;
 
 /**
- * Get the visible text content of an element
+ * Widget roles that support "name from content" per the ARIA specification.
+ * The ACT rule 2ee8b8 only applies to elements whose semantic role is a
+ * widget that supports naming from content.
+ */
+const widgetRolesWithNameFromContent = new Set([
+  "button",
+  "checkbox",
+  "columnheader",
+  "gridcell",
+  "link",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "option",
+  "radio",
+  "rowheader",
+  "switch",
+  "tab",
+  "treeitem",
+]);
+
+/**
+ * Map from HTML element tag names to their implicit ARIA roles
+ * (only for widget roles that name from content).
+ */
+function getImplicitRole(element: Element): string | null {
+  const tag = element.tagName.toLowerCase();
+  if (tag === "a" && element.hasAttribute("href")) return "link";
+  if (tag === "button") return "button";
+  if (tag === "summary") return "button";
+  if (tag === "option") return "option";
+  if (tag === "th") {
+    // th can be columnheader or rowheader depending on scope
+    const scope = element.getAttribute("scope");
+    if (scope === "row") return "rowheader";
+    return "columnheader";
+  }
+  if (tag === "td") return "gridcell";
+  return null;
+}
+
+/**
+ * Get the effective role of an element.
+ */
+function getEffectiveRole(element: Element): string | null {
+  const explicitRole = element.getAttribute("role")?.trim().split(/\s+/)[0];
+  if (explicitRole) return explicitRole;
+  return getImplicitRole(element);
+}
+
+/**
+ * Get the visible text content of an element, considering only direct
+ * text node descendants (not alt text of images, etc.).
  */
 function getVisibleText(element: Element): string {
-  // Get text content and normalize whitespace
-  const textContent = element.textContent?.trim() || "";
-  // Normalize multiple whitespaces to single space
-  return textContent.replaceAll(/\s+/g, " ");
+  let text = "";
+  for (const node of element.childNodes) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      text += node.textContent || "";
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      const child = node as Element;
+      // Skip hidden elements
+      if (child.getAttribute("aria-hidden") === "true") continue;
+      // Skip img elements (their alt text is not "visible text")
+      if (child.tagName.toLowerCase() === "img") continue;
+      // Recurse into child elements for their text nodes
+      text += getVisibleText(child);
+    }
+  }
+  // Normalize whitespace
+  return text.trim().replaceAll(/\s+/g, " ");
+}
+
+/**
+ * Check if the visible text is a single character, which the ACT rule
+ * considers potentially symbolic/iconic and therefore excluded.
+ */
+function isSingleCharacter(text: string): boolean {
+  // After normalization, check if it's a single unicode character
+  const chars = [...text];
+  return chars.length === 1;
 }
 
 /**
  * Get the accessible name of an element (from aria-label or aria-labelledby)
  */
 function getAccessibleName(element: Element): string | null {
-  // Check aria-label
-  const ariaLabel = element.getAttribute("aria-label");
-  if (ariaLabel) {
-    return ariaLabel.trim().replaceAll(/\s+/g, " ");
-  }
-
-  // Check aria-labelledby
+  // Check aria-labelledby first (takes precedence over aria-label)
   const labelledBy = element.getAttribute("aria-labelledby");
   if (labelledBy) {
     const ids = labelledBy.split(/\s+/);
     const texts: string[] = [];
-    for (const id of ids) {
-      // Escape the ID to prevent CSS injection
-      const escapedId = CSS.escape(id);
+    for (const refId of ids) {
+      const escapedId = CSS.escape(refId);
       const labelElement = element.ownerDocument.querySelector(`#${escapedId}`);
       if (labelElement) {
         const labelText = labelElement.textContent?.trim() || "";
@@ -45,6 +112,12 @@ function getAccessibleName(element: Element): string | null {
     if (texts.length > 0) {
       return texts.join(" ").replaceAll(/\s+/g, " ");
     }
+  }
+
+  // Check aria-label
+  const ariaLabel = element.getAttribute("aria-label");
+  if (ariaLabel) {
+    return ariaLabel.trim().replaceAll(/\s+/g, " ");
   }
 
   return null;
@@ -59,7 +132,6 @@ function isTextPartOfAccessibleName(
 ): boolean {
   if (!visibleText || !accessibleName) return true;
 
-  // Normalize both strings for case-insensitive comparison
   const normalizedVisible = visibleText.toLowerCase();
   const normalizedAccessible = accessibleName.toLowerCase();
 
@@ -69,18 +141,15 @@ function isTextPartOfAccessibleName(
 export default function (element: Element): AccessibilityError[] {
   const errors: AccessibilityError[] = [];
 
-  // Select elements that could have this issue
-  // These are typically interactive elements with roles
+  // Select elements that could have this issue — interactive widgets
+  // that support name from content
   const selector = [
     "a[href]",
     "button",
-    "[role='button']",
-    "[role='link']",
-    "[role='menuitem']",
-    "[role='menuitemcheckbox']",
-    "[role='menuitemradio']",
-    "[role='tab']",
-    "[role='treeitem']",
+    "summary",
+    "option",
+    "th",
+    "[role]",
   ].join(", ");
 
   const elements = querySelectorAll(selector, element);
@@ -92,6 +161,10 @@ export default function (element: Element): AccessibilityError[] {
     // Skip if element is hidden
     if (el.getAttribute("aria-hidden") === "true") continue;
 
+    // Check that the element has a widget role that names from content
+    const role = getEffectiveRole(el);
+    if (!role || !widgetRolesWithNameFromContent.has(role)) continue;
+
     const visibleText = getVisibleText(el);
     const accessibleName = getAccessibleName(el);
 
@@ -99,6 +172,9 @@ export default function (element: Element): AccessibilityError[] {
     // 1. Element has visible text content
     // 2. Element has an accessible name from aria-label or aria-labelledby
     if (!visibleText || !accessibleName) continue;
+
+    // Skip single-character visible text (treated as potentially symbolic)
+    if (isSingleCharacter(visibleText)) continue;
 
     // Check if visible text is part of accessible name
     if (!isTextPartOfAccessibleName(visibleText, accessibleName)) {

--- a/tests/act/tests/2ee8b8/02f6608c4242efccba3ceeb8b73cc6b1255e362d.ts
+++ b/tests/act/tests/2ee8b8/02f6608c4242efccba3ceeb8b73cc6b1255e362d.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2ee8b8]Visible label is part of accessible name", function () {
+  it("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2ee8b8/02f6608c4242efccba3ceeb8b73cc6b1255e362d.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 2</title>
+</head>
+<body>
+	<a href="https://act-rules.github.io/" aria-label="  ACT rules  ">ACT rules</a>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/label-content-name-mismatch"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/2ee8b8/20a5e321fc6a5cb2bfcd520acb8cda21e6925254.ts
+++ b/tests/act/tests/2ee8b8/20a5e321fc6a5cb2bfcd520acb8cda21e6925254.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2ee8b8]Visible label is part of accessible name", function () {
+  it("Failed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2ee8b8/20a5e321fc6a5cb2bfcd520acb8cda21e6925254.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 3</title>
+</head>
+<body>
+	<a href="/" aria-label="Proof of two multiplied by two is four">Proof of 2&times;2=4</a>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/label-content-name-mismatch"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/2ee8b8/326f6768ecbf60ca31149e65ab2853c138095fd7.ts
+++ b/tests/act/tests/2ee8b8/326f6768ecbf60ca31149e65ab2853c138095fd7.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2ee8b8]Visible label is part of accessible name", function () {
+  it("Passed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2ee8b8/326f6768ecbf60ca31149e65ab2853c138095fd7.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 1</title>
+</head>
+<body>
+	<a href="https://act-rules.github.io/" aria-label="ACT rules">ACT rules</a>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/label-content-name-mismatch"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/2ee8b8/4ee91039726503da19c9bc58e08e800464d94d82.ts
+++ b/tests/act/tests/2ee8b8/4ee91039726503da19c9bc58e08e800464d94d82.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2ee8b8]Visible label is part of accessible name", function () {
+  it("Failed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2ee8b8/4ee91039726503da19c9bc58e08e800464d94d82.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 1</title>
+</head>
+<body>
+	<a href="https://act-rules.github.io/" aria-label="WCAG">ACT rules</a>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/label-content-name-mismatch"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/2ee8b8/71c4a612a2e00a8abd3d33b4a66ca8e5079fff1b.ts
+++ b/tests/act/tests/2ee8b8/71c4a612a2e00a8abd3d33b4a66ca8e5079fff1b.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2ee8b8]Visible label is part of accessible name", function () {
+  it("Passed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2ee8b8/71c4a612a2e00a8abd3d33b4a66ca8e5079fff1b.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 3</title>
+</head>
+<body>
+	<a href="https://act-rules.github.io/" aria-label="act rules">ACT rules</a>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/label-content-name-mismatch"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/2ee8b8/79af5d3e531aecd27961f0b9ed260d95f39440c0.ts
+++ b/tests/act/tests/2ee8b8/79af5d3e531aecd27961f0b9ed260d95f39440c0.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2ee8b8]Visible label is part of accessible name", function () {
+  it("Passed Example 5 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2ee8b8/79af5d3e531aecd27961f0b9ed260d95f39440c0.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 5</title>
+</head>
+<body>
+	<button aria-label="anything">X</button>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/label-content-name-mismatch"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/2ee8b8/8db20b5fa0a59906a7b182c5698d6a9ce7e85f10.ts
+++ b/tests/act/tests/2ee8b8/8db20b5fa0a59906a7b182c5698d6a9ce7e85f10.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2ee8b8]Visible label is part of accessible name", function () {
+  it("Failed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2ee8b8/8db20b5fa0a59906a7b182c5698d6a9ce7e85f10.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 2</title>
+</head>
+<body>
+	<button aria-label="the full">The full label</button>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/label-content-name-mismatch"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/2ee8b8/e9bbdbec137223e2973c6d2896050770c84c26e5.ts
+++ b/tests/act/tests/2ee8b8/e9bbdbec137223e2973c6d2896050770c84c26e5.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2ee8b8]Visible label is part of accessible name", function () {
+  it("Failed Example 4 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2ee8b8/e9bbdbec137223e2973c6d2896050770c84c26e5.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 4</title>
+</head>
+<body>
+	<a href="#" aria-label="non-standard">nonstandard</a>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/label-content-name-mismatch"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/2ee8b8/efa9543339cdad5412c7719b266a633a29ce149e.ts
+++ b/tests/act/tests/2ee8b8/efa9543339cdad5412c7719b266a633a29ce149e.ts
@@ -1,0 +1,32 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2ee8b8]Visible label is part of accessible name", function () {
+  it.skip("Passed Example 6 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2ee8b8/efa9543339cdad5412c7719b266a633a29ce149e.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 6</title>
+</head>
+<body>
+	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+	<style>
+		button {
+			font-family: 'Material Icons';
+		}
+	</style>
+	<button aria-label="Find">search</button>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/label-content-name-mismatch"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/2ee8b8/f88ac89cc14d59302666047a0da91bbc51d27bb2.ts
+++ b/tests/act/tests/2ee8b8/f88ac89cc14d59302666047a0da91bbc51d27bb2.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2ee8b8]Visible label is part of accessible name", function () {
+  it("Passed Example 4 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2ee8b8/f88ac89cc14d59302666047a0da91bbc51d27bb2.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 4</title>
+</head>
+<body>
+	<button aria-label="Next Page in the list">Next Page</button>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/label-content-name-mismatch"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/2ee8b8/fd0c075f565b6f42be0ded6a959bea82ebff15e5.ts
+++ b/tests/act/tests/2ee8b8/fd0c075f565b6f42be0ded6a959bea82ebff15e5.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2ee8b8]Visible label is part of accessible name", function () {
+  it("Failed Example 5 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2ee8b8/fd0c075f565b6f42be0ded6a959bea82ebff15e5.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 5</title>
+</head>
+<body>
+	<a aria-label="1 2 3. 4 5 6. 7 8 9 0" href="tel:1234567890">123.456.7890</a>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/label-content-name-mismatch"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
- Improved the `label-content-name-mismatch` rule to properly implement ACT rule 2ee8b8 (Visible label is part of accessible name, WCAG 2.5.3 Level A)
- Restricted applicability to widget roles that support "name from content" per the ARIA spec, fixing false positives on non-widget elements like `<nav>`, `<input>`, and `<div role="tooltip">`
- Added single-character text exclusion (treated as potentially symbolic/iconic per the ACT rule definition)
- Extracted visible text from text nodes only, excluding image alt text
- Enabled ACT tests for rule 2ee8b8: 10 tests passing, 1 skipped (icon font detection requires CSS rendering)

Closes #354

## Test plan
- [x] All 252 existing tests pass
- [x] 10 new ACT test cases for rule 2ee8b8 pass (6 passed examples, 5 failed examples expected to flag errors)
- [x] 1 ACT test skipped: Passed Example 6 uses Material Icons font — detecting icon fonts requires CSS rendering which is beyond DOM-only analysis
- [x] `npm run format` passes
- [x] `npm run build:readme` updates README

🤖 Generated with [Claude Code](https://claude.com/claude-code)