### PR TITLE
Enable ACT tests for aria-command-name rule (97a4e1, m6b1q3)

### DIFF
--- a/generate-act-tests.js
+++ b/generate-act-tests.js
@@ -108,10 +108,8 @@ const rulesToIgnore = [
   "23a2a8", // Image has non-empty accessible name - not implemented
   "59796f", // Image button has non-empty accessible name - not implemented
   "7d6734", // SVG element with explicit role has non-empty accessible name - not implemented
-  "97a4e1", // Button has non-empty accessible name - not implemented
   "cae760", // Iframe element has non-empty accessible name - not implemented
   "e086e5", // Form field has non-empty accessible name - not implemented
-  "m6b1q3", // Menuitem has non-empty accessible name - not implemented
 
   // --- Not implemented - ARIA rules not yet fully supported ---
   "4e8ab6", // Element with role attribute has required states and properties - not implemented

--- a/rules.json
+++ b/rules.json
@@ -23,7 +23,7 @@
         "ACT Rules": "[5c01ea](https://act-rules.github.io/rules/5c01ea)"
       },
       {
-        "implemented": "❌",
+        "implemented": "✅",
         "id": "aria-command-name",
         "url": "https://dequeuniversity.com/rules/axe/4.11/aria-command-name?application=RuleDescription",
         "Description": "Ensures every ARIA button, link and menuitem has an accessible name",

--- a/tests/act/tests/97a4e1/00fe207175e40ddc81a86fb09504e5fa33b7dd0f.ts
+++ b/tests/act/tests/97a4e1/00fe207175e40ddc81a86fb09504e5fa33b7dd0f.ts
@@ -1,0 +1,30 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[97a4e1]Button has non-empty accessible name", function () {
+  it("Passed Example 6 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/97a4e1/00fe207175e40ddc81a86fb09504e5fa33b7dd0f.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<style>
+		.notInPage {
+			position: absolute;
+			left: -9999px;
+			top: -9999px;
+		}
+	</style>
+	<body>
+		<button class="notInPage">Save</button>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-command-name","https://dequeuniversity.com/rules/axe/4.11/button-name","https://dequeuniversity.com/rules/axe/4.11/input-button-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/97a4e1/1a6035f4f09b339ac53bc547fc727a51ab05a3c6.ts
+++ b/tests/act/tests/97a4e1/1a6035f4f09b339ac53bc547fc727a51ab05a3c6.ts
@@ -1,0 +1,30 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[97a4e1]Button has non-empty accessible name", function () {
+  it("Failed Example 4 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/97a4e1/1a6035f4f09b339ac53bc547fc727a51ab05a3c6.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<style>
+		.notInPage {
+			position: absolute;
+			left: -9999px;
+			top: -9999px;
+		}
+	</style>
+	<body>
+		<button class="notInPage" value="delete"></button>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-command-name","https://dequeuniversity.com/rules/axe/4.11/button-name","https://dequeuniversity.com/rules/axe/4.11/input-button-name"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/97a4e1/1ec8deb0b18514b612774d3af39b5ad41f2a792b.ts
+++ b/tests/act/tests/97a4e1/1ec8deb0b18514b612774d3af39b5ad41f2a792b.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[97a4e1]Button has non-empty accessible name", function () {
+  it("Failed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/97a4e1/1ec8deb0b18514b612774d3af39b5ad41f2a792b.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 1</title>
+</head>
+<body>
+	<button></button>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-command-name","https://dequeuniversity.com/rules/axe/4.11/button-name","https://dequeuniversity.com/rules/axe/4.11/input-button-name"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/97a4e1/2c5b0625e21b3503d1cd4c4daf53b15ae41c562d.ts
+++ b/tests/act/tests/97a4e1/2c5b0625e21b3503d1cd4c4daf53b15ae41c562d.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[97a4e1]Button has non-empty accessible name", function () {
+  it("Failed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/97a4e1/2c5b0625e21b3503d1cd4c4daf53b15ae41c562d.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 2</title>
+</head>
+<body>
+	<button type="button" value="read more"></button>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-command-name","https://dequeuniversity.com/rules/axe/4.11/button-name","https://dequeuniversity.com/rules/axe/4.11/input-button-name"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/97a4e1/3004e7b1a47b2e5a5c77b3eef36b50d495c9e4a1.ts
+++ b/tests/act/tests/97a4e1/3004e7b1a47b2e5a5c77b3eef36b50d495c9e4a1.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[97a4e1]Button has non-empty accessible name", function () {
+  it("Passed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/97a4e1/3004e7b1a47b2e5a5c77b3eef36b50d495c9e4a1.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 3</title>
+</head>
+<body>
+	<button aria-label="My button"></button>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-command-name","https://dequeuniversity.com/rules/axe/4.11/button-name","https://dequeuniversity.com/rules/axe/4.11/input-button-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/97a4e1/3fe70212e0020d7fa552b7c6c035a466c900c4b9.ts
+++ b/tests/act/tests/97a4e1/3fe70212e0020d7fa552b7c6c035a466c900c4b9.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[97a4e1]Button has non-empty accessible name", function () {
+  it("Passed Example 7 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/97a4e1/3fe70212e0020d7fa552b7c6c035a466c900c4b9.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 7</title>
+</head>
+<body>
+	<input type="reset" />
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-command-name","https://dequeuniversity.com/rules/axe/4.11/button-name","https://dequeuniversity.com/rules/axe/4.11/input-button-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/97a4e1/5bfdf45a98f7d2f0e93a700f7ce0fe5f723bf0f7.ts
+++ b/tests/act/tests/97a4e1/5bfdf45a98f7d2f0e93a700f7ce0fe5f723bf0f7.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[97a4e1]Button has non-empty accessible name", function () {
+  it("Passed Example 5 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/97a4e1/5bfdf45a98f7d2f0e93a700f7ce0fe5f723bf0f7.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 5</title>
+</head>
+<body>
+	<button disabled>Delete</button>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-command-name","https://dequeuniversity.com/rules/axe/4.11/button-name","https://dequeuniversity.com/rules/axe/4.11/input-button-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/97a4e1/a4cc71b0434f71f4ea0069c409f73e0207dfb403.ts
+++ b/tests/act/tests/97a4e1/a4cc71b0434f71f4ea0069c409f73e0207dfb403.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[97a4e1]Button has non-empty accessible name", function () {
+  it("Passed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/97a4e1/a4cc71b0434f71f4ea0069c409f73e0207dfb403.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 1</title>
+</head>
+<body>
+	<button>My button</button>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-command-name","https://dequeuniversity.com/rules/axe/4.11/button-name","https://dequeuniversity.com/rules/axe/4.11/input-button-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/97a4e1/ac9a749a026c47209c34677ca6ac0dc093d24888.ts
+++ b/tests/act/tests/97a4e1/ac9a749a026c47209c34677ca6ac0dc093d24888.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[97a4e1]Button has non-empty accessible name", function () {
+  it("Failed Example 5 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/97a4e1/ac9a749a026c47209c34677ca6ac0dc093d24888.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 5</title>
+</head>
+<body>
+	<button role="none"></button>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-command-name","https://dequeuniversity.com/rules/axe/4.11/button-name","https://dequeuniversity.com/rules/axe/4.11/input-button-name"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/97a4e1/d9adf41033a5b71a0730b6df8c1c7e01088e9022.ts
+++ b/tests/act/tests/97a4e1/d9adf41033a5b71a0730b6df8c1c7e01088e9022.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[97a4e1]Button has non-empty accessible name", function () {
+  it("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/97a4e1/d9adf41033a5b71a0730b6df8c1c7e01088e9022.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 2</title>
+</head>
+<body>
+	<input type="submit" value="Submit" />
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-command-name","https://dequeuniversity.com/rules/axe/4.11/button-name","https://dequeuniversity.com/rules/axe/4.11/input-button-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/97a4e1/ff4b76894bd9aaad29242e72fe93fd9798bf85af.ts
+++ b/tests/act/tests/97a4e1/ff4b76894bd9aaad29242e72fe93fd9798bf85af.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[97a4e1]Button has non-empty accessible name", function () {
+  it("Passed Example 4 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/97a4e1/ff4b76894bd9aaad29242e72fe93fd9798bf85af.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 4</title>
+</head>
+<body>
+	<span role="button" aria-label="My button"></span>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-command-name","https://dequeuniversity.com/rules/axe/4.11/button-name","https://dequeuniversity.com/rules/axe/4.11/input-button-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/97a4e1/ffe1796f06e1082a8ddae54a471dcca66c783c4e.ts
+++ b/tests/act/tests/97a4e1/ffe1796f06e1082a8ddae54a471dcca66c783c4e.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[97a4e1]Button has non-empty accessible name", function () {
+  it("Failed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/97a4e1/ffe1796f06e1082a8ddae54a471dcca66c783c4e.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 3</title>
+</head>
+<body>
+	<span role="button"></span>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-command-name","https://dequeuniversity.com/rules/axe/4.11/button-name","https://dequeuniversity.com/rules/axe/4.11/input-button-name"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/m6b1q3/78c41b8461997477cb7b6a9d163ba8a387ad56b8.ts
+++ b/tests/act/tests/m6b1q3/78c41b8461997477cb7b6a9d163ba8a387ad56b8.ts
@@ -1,0 +1,30 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[m6b1q3]Menuitem has non-empty accessible name", function () {
+  it("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/m6b1q3/78c41b8461997477cb7b6a9d163ba8a387ad56b8.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 2</title>
+</head>
+<body>
+	<div role="menu">
+		<button role="menuitem" aria-label="New file">
+			<img src="/WAI/content-assets/wcag-act-rules/test-assets/shared/file.svg" alt="" />
+		</button>
+	</div>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/button-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/m6b1q3/83a0c030f9172c3d8d862d01138e75ec7aaf4f4e.ts
+++ b/tests/act/tests/m6b1q3/83a0c030f9172c3d8d862d01138e75ec7aaf4f4e.ts
@@ -1,0 +1,31 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[m6b1q3]Menuitem has non-empty accessible name", function () {
+  it("Passed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/m6b1q3/83a0c030f9172c3d8d862d01138e75ec7aaf4f4e.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 3</title>
+</head>
+<body>
+	<div role="menu">
+		<button role="menuitem" aria-labelledby="newfile">
+			<img src="/WAI/content-assets/wcag-act-rules/test-assets/shared/file.svg" alt="" />
+			<span id="newfile" hidden>New file</span>
+		</button>
+	</div>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/button-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/m6b1q3/895a5b0d06d892bc50351cfd2db426b31cfcc97f.ts
+++ b/tests/act/tests/m6b1q3/895a5b0d06d892bc50351cfd2db426b31cfcc97f.ts
@@ -1,0 +1,28 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[m6b1q3]Menuitem has non-empty accessible name", function () {
+  it("Passed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/m6b1q3/895a5b0d06d892bc50351cfd2db426b31cfcc97f.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 1</title>
+</head>
+<body>
+	<div role="menu">
+		<button role="menuitem">New file</button>
+	</div>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/button-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/m6b1q3/c05155744a79e6ff72f1b691b8bae15338e8146b.ts
+++ b/tests/act/tests/m6b1q3/c05155744a79e6ff72f1b691b8bae15338e8146b.ts
@@ -1,0 +1,30 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[m6b1q3]Menuitem has non-empty accessible name", function () {
+  it("Passed Example 4 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/m6b1q3/c05155744a79e6ff72f1b691b8bae15338e8146b.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 4</title>
+</head>
+<body>
+	<div role="menu">
+		<button role="menuitem" title="New file">
+			<img src="/WAI/content-assets/wcag-act-rules/test-assets/shared/file.svg" alt="" />
+		</button>
+	</div>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/button-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/m6b1q3/c261108b8bb62e118a47a52d0a157b4265a6e143.ts
+++ b/tests/act/tests/m6b1q3/c261108b8bb62e118a47a52d0a157b4265a6e143.ts
@@ -1,0 +1,32 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[m6b1q3]Menuitem has non-empty accessible name", function () {
+  it("Failed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/m6b1q3/c261108b8bb62e118a47a52d0a157b4265a6e143.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+	<style>
+		.offscreen {
+			position: absolute;
+			left: -9999px;
+			top: -9999px;
+		}
+	</style>
+	<div role="menu" class="offscreen">
+		<button role="menuitem">
+			<img src="/WAI/content-assets/wcag-act-rules/test-assets/shared/file.svg" alt="" />
+		</button>
+	</div>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/button-name"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/m6b1q3/f3a40579bcb3cab4f12a31639bc9dd0ca5c14d87.ts
+++ b/tests/act/tests/m6b1q3/f3a40579bcb3cab4f12a31639bc9dd0ca5c14d87.ts
@@ -1,0 +1,30 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[m6b1q3]Menuitem has non-empty accessible name", function () {
+  it("Failed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/m6b1q3/f3a40579bcb3cab4f12a31639bc9dd0ca5c14d87.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 1</title>
+</head>
+<body>
+	<div role="menu">
+		<button role="menuitem">
+			<img src="/WAI/content-assets/wcag-act-rules/test-assets/shared/file.svg" alt="" />
+		</button>
+	</div>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/button-name"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
- Mark `aria-command-name` as implemented in rules.json (rule was already correctly implemented)
- Enable ACT test suites for rules 97a4e1 and m6b1q3 (18 new test cases, all passing)

## Test plan
- [x] All 338 tests pass
- [x] `npm run format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)