### PR TITLE
Enable ACT tests for aria-input-field-name and aria-toggle-field-name (e086e5)

### DIFF
--- a/generate-act-tests.js
+++ b/generate-act-tests.js
@@ -102,10 +102,9 @@ const rulesToIgnore = [
   "c249d5", // Device motion based changes to the content can be disabled - requires device motion events
 
   // --- Not implemented - accessible name computation not yet fully supported ---
-"59796f", // Image button has non-empty accessible name - not implemented
+  "59796f", // Image button has non-empty accessible name - not implemented
   "7d6734", // SVG element with explicit role has non-empty accessible name - not implemented
   "cae760", // Iframe element has non-empty accessible name - not implemented
-  "e086e5", // Form field has non-empty accessible name - not implemented
 
   // --- Not implemented - ARIA rules not yet fully supported ---
   "4e8ab6", // Element with role attribute has required states and properties - not implemented
@@ -208,6 +207,9 @@ const skippedExamples = [
 
   // [e88epe] decorative-image: scanner does not analyse canvas visual content
   "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e88epe/6d108d00cc7a54f66547f02d7e7606342b11f801.html",
+
+  // [e086e5] form-field-name: label rule intentionally skips disabled inputs
+  "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/5c0ba53d53cc9fd8627f224b39db30bd9ffa5757.html",
 
   // [80f0bf] no-autoplay-audio: scanner can't detect short media duration from URL fragment (#t=8,10)
   "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/80f0bf/e4d78b5074773ab0cbd8c72732e948c4608f5c9d.html",

--- a/rules.json
+++ b/rules.json
@@ -53,7 +53,7 @@
         "ACT Rules": "[6cfa84](https://act-rules.github.io/rules/6cfa84)"
       },
       {
-        "implemented": "❌",
+        "implemented": "✅",
         "id": "aria-input-field-name",
         "url": "https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name?application=RuleDescription",
         "Description": "Ensures every ARIA input field has an accessible name",
@@ -133,7 +133,7 @@
         "ACT Rules": "[674b10](https://act-rules.github.io/rules/674b10)"
       },
       {
-        "implemented": "❌",
+        "implemented": "✅",
         "id": "aria-toggle-field-name",
         "url": "https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name?application=RuleDescription",
         "Description": "Ensures every ARIA toggle field has an accessible name",

--- a/src/rules/aria-toggle-field-name.ts
+++ b/src/rules/aria-toggle-field-name.ts
@@ -34,6 +34,11 @@ function hasAccessibleName(element: Element): boolean {
     return element.getAttribute("title")!.trim() !== "";
   }
 
+  // Check for text content (toggle fields can derive their name from content)
+  if (element.textContent && element.textContent.trim() !== "") {
+    return true;
+  }
+
   return false;
 }
 

--- a/src/rules/label.ts
+++ b/src/rules/label.ts
@@ -36,7 +36,7 @@ export default function (element: Element): AccessibilityError[] {
     )
       continue;
 
-    if (element.getAttribute("aria-label")) continue;
+    if (element.getAttribute("aria-label")?.trim()) continue;
     if (labelledByIsValid(element)) continue;
     if (element.getAttribute("title")) continue;
     if (element.getAttribute("placeholder")) continue;

--- a/tests/act/tests/e086e5/004258203c8bf167307b6ed79f765115d16a6357.ts
+++ b/tests/act/tests/e086e5/004258203c8bf167307b6ed79f765115d16a6357.ts
@@ -1,0 +1,27 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Failed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/004258203c8bf167307b6ed79f765115d16a6357.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 1</title>
+</head>
+<body>
+	<div>last name</div>
+	<input />
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/e086e5/09ea6ee13f7f26b0d6e3103946209ea0726876de.ts
+++ b/tests/act/tests/e086e5/09ea6ee13f7f26b0d6e3103946209ea0726876de.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Passed Example 7 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/09ea6ee13f7f26b0d6e3103946209ea0726876de.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 7</title>
+</head>
+<body>
+	<div role="checkbox">I agree to the terms and conditions.</div>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/e086e5/2183d2e337eec311b7c2e06c2f9cec759913dba9.ts
+++ b/tests/act/tests/e086e5/2183d2e337eec311b7c2e06c2f9cec759913dba9.ts
@@ -1,0 +1,27 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Passed Example 4 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/2183d2e337eec311b7c2e06c2f9cec759913dba9.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 4</title>
+</head>
+<body>
+	<div id="country">Country</div>
+	<textarea aria-labelledby="country"></textarea>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/e086e5/366e62d83ede9df9fdad86cf7040600916bb065a.ts
+++ b/tests/act/tests/e086e5/366e62d83ede9df9fdad86cf7040600916bb065a.ts
@@ -1,0 +1,27 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/366e62d83ede9df9fdad86cf7040600916bb065a.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 2</title>
+</head>
+<body>
+	<div>last name</div>
+	<input aria-label="last name" disabled />
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/e086e5/3aa8f45d7e358655c39708e2656a2c2d97e7dfa6.ts
+++ b/tests/act/tests/e086e5/3aa8f45d7e358655c39708e2656a2c2d97e7dfa6.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Passed Example 5 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/3aa8f45d7e358655c39708e2656a2c2d97e7dfa6.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 5</title>
+</head>
+<body>
+	<input placeholder="Your search query" /> <button type="submit">search</button>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/e086e5/4246616cd947040f64dc183b66e1f6c30b2d7fbb.ts
+++ b/tests/act/tests/e086e5/4246616cd947040f64dc183b66e1f6c30b2d7fbb.ts
@@ -1,0 +1,27 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Failed Example 6 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/4246616cd947040f64dc183b66e1f6c30b2d7fbb.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 6</title>
+</head>
+<body>
+	<label for="firstname">first name</label>
+	<div role="textbox" id="firstname"></div>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/e086e5/552732aff853ed413ed7b5ff4a6202d11fd0c1a5.ts
+++ b/tests/act/tests/e086e5/552732aff853ed413ed7b5ff4a6202d11fd0c1a5.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Failed Example 5 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/552732aff853ed413ed7b5ff4a6202d11fd0c1a5.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 5</title>
+</head>
+<body>
+	<label>
+		first name
+		<div role="textbox"></div>
+	</label>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/e086e5/5c0ba53d53cc9fd8627f224b39db30bd9ffa5757.ts
+++ b/tests/act/tests/e086e5/5c0ba53d53cc9fd8627f224b39db30bd9ffa5757.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it.skip("Failed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/5c0ba53d53cc9fd8627f224b39db30bd9ffa5757.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 2</title>
+</head>
+<body>
+	<input disabled />
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/e086e5/6726b79b0534d80f567c3e5fd7174962d411be95.ts
+++ b/tests/act/tests/e086e5/6726b79b0534d80f567c3e5fd7174962d411be95.ts
@@ -1,0 +1,32 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Passed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/6726b79b0534d80f567c3e5fd7174962d411be95.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 3</title>
+</head>
+<body>
+	<label for="country">Country</label>
+	<select id="country">
+		<option>England</option>
+		<option>Scotland</option>
+		<option>Wales</option>
+		<option>Northern Ireland</option>
+	</select>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/e086e5/80a5df2346e082cd0be260143ac9090a902bcf30.ts
+++ b/tests/act/tests/e086e5/80a5df2346e082cd0be260143ac9090a902bcf30.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Failed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/80a5df2346e082cd0be260143ac9090a902bcf30.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 3</title>
+</head>
+<body>
+	<input aria-label=" " />
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/e086e5/933cad4e69415e2a2970832d2d60e2b854bca1b4.ts
+++ b/tests/act/tests/e086e5/933cad4e69415e2a2970832d2d60e2b854bca1b4.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Passed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/933cad4e69415e2a2970832d2d60e2b854bca1b4.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 1</title>
+</head>
+<body>
+	<label>
+		first name
+		<input />
+	</label>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/e086e5/a59cf1abfabcb96ab4592966bb4a78e788b41017.ts
+++ b/tests/act/tests/e086e5/a59cf1abfabcb96ab4592966bb4a78e788b41017.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Failed Example 4 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/a59cf1abfabcb96ab4592966bb4a78e788b41017.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 4</title>
+</head>
+<body>
+	<div id="country"></div>
+	<select aria-labelledby="country">
+		<option>England</option>
+	</select>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/e086e5/b0c554cfdddfdc0fe15923066b329868dd9e70c8.ts
+++ b/tests/act/tests/e086e5/b0c554cfdddfdc0fe15923066b329868dd9e70c8.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Failed Example 7 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/b0c554cfdddfdc0fe15923066b329868dd9e70c8.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 7</title>
+</head>
+<body>
+	<div role="textbox">first name</div>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/e086e5/bd816c3ef10b8982f18411e1623887d2444d7311.ts
+++ b/tests/act/tests/e086e5/bd816c3ef10b8982f18411e1623887d2444d7311.ts
@@ -1,0 +1,30 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Failed Example 8 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/bd816c3ef10b8982f18411e1623887d2444d7311.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 8</title>
+</head>
+<body>
+	<p id="dip">Add one or more dip:</p>
+	<div role="menu" aria-labelledby="dip">
+		<input type="checkbox" role="menuitemcheckbox" /><span aria-hidden="true">Ketchup</span><br />
+		<input type="checkbox" role="menuitemcheckbox" /><span aria-hidden="true">Mayonnaise</span>
+	</div>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/e086e5/ca41ec5f1dba602b8b6e332ad524cbfc5cd1505e.ts
+++ b/tests/act/tests/e086e5/ca41ec5f1dba602b8b6e332ad524cbfc5cd1505e.ts
@@ -1,0 +1,27 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Passed Example 6 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/ca41ec5f1dba602b8b6e332ad524cbfc5cd1505e.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 6</title>
+</head>
+<body>
+	<div>Country</div>
+	<div aria-label="country" role="combobox" aria-disabled="true">England</div>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/e086e5/cfb1790405bb1ff793ed15a73372d53e79d2d7e0.ts
+++ b/tests/act/tests/e086e5/cfb1790405bb1ff793ed15a73372d53e79d2d7e0.ts
@@ -1,0 +1,34 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Passed Example 8 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/cfb1790405bb1ff793ed15a73372d53e79d2d7e0.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 8</title>
+</head>
+<body>
+	<p id="dip">Add one or more dip:</p>
+	<div role="menu" aria-labelledby="dip">
+		<input type="checkbox" role="menuitemcheckbox" aria-labelledby="ketchup" /><span id="ketchup" aria-hidden="true"
+			>Ketchup</span
+		><br />
+		<input type="checkbox" role="menuitemcheckbox" aria-labelledby="mayonnaise" /><span id="mayonnaise" aria-hidden="true"
+			>Mayonnaise</span
+		>
+	</div>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/e086e5/d9ee6c2ae6da41521bd4ba0bf25c4b6bcd253f37.ts
+++ b/tests/act/tests/e086e5/d9ee6c2ae6da41521bd4ba0bf25c4b6bcd253f37.ts
@@ -1,0 +1,33 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[e086e5]Form field has non-empty accessible name", function () {
+  it("Passed Example 8 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e086e5/d9ee6c2ae6da41521bd4ba0bf25c4b6bcd253f37.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 8</title>
+</head>
+<body>
+	<p id="dip">Add one or more dip:</p>
+	<div role="menu" aria-labelledby="dip">
+		<input type="checkbox" role="menuitemcheckbox" aria-labelledby="ketchup" /><span id="ketchup" aria-hidden="true">Ketchup</span
+		><br />
+		<input type="checkbox" role="menuitemcheckbox" aria-labelledby="mayonnaise" /><span id="mayonnaise" aria-hidden="true"
+			>Mayonnaise</span
+		>
+	</div>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name","https://dequeuniversity.com/rules/axe/4.11/aria-toggle-field-name","https://dequeuniversity.com/rules/axe/4.11/label","https://dequeuniversity.com/rules/axe/4.11/select-name"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});


### PR DESCRIPTION
## Summary
- Mark `aria-input-field-name` and `aria-toggle-field-name` as implemented
- Fix `aria-toggle-field-name` to recognize text content as accessible name
- Fix `label` rule to trim whitespace-only `aria-label` values
- Enable 17 ACT test cases for rule e086e5 (1 skipped for disabled input design difference)

## Test plan
- [x] All 337 tests pass
- [x] `npm run format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)