### PR TITLE
Fix wrapper-text, sr-only, and scrollable-region false positives

### DIFF
--- a/src/rules/color-contrast.ts
+++ b/src/rules/color-contrast.ts
@@ -23,6 +23,34 @@ interface ContrastError extends AccessibilityError {
 }
 
 /**
+ * Detect screen-reader-only patterns (visually clipped, not rendered).
+ */
+function isVisuallyHidden(computed: CSSStyleDeclaration): boolean {
+  const clipPath = computed.clipPath;
+  if (clipPath === "inset(50%)" || clipPath === "inset(100%)") return true;
+
+  const clip = computed.clip;
+  if (
+    clip === "rect(0px, 0px, 0px, 0px)" ||
+    clip === "rect(1px, 1px, 1px, 1px)"
+  ) {
+    return true;
+  }
+
+  // 1x1 absolutely-positioned with overflow:hidden — classic sr-only fallback.
+  if (
+    computed.position === "absolute" &&
+    computed.overflow === "hidden" &&
+    parseFloat(computed.width) <= 1 &&
+    parseFloat(computed.height) <= 1
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
  * Check if element has visible text content
  */
 function hasTextContent(element: Element): boolean {
@@ -39,6 +67,10 @@ function hasTextContent(element: Element): boolean {
     return false;
   }
 
+  if (isVisuallyHidden(computed)) {
+    return false;
+  }
+
   // Check if element has zero dimensions
   const rect = (element as HTMLElement).getBoundingClientRect();
   if (rect.width === 0 || rect.height === 0) {
@@ -46,6 +78,20 @@ function hasTextContent(element: Element): boolean {
   }
 
   return true;
+}
+
+/**
+ * True if the element has a non-empty direct text-node child.
+ * Wrappers that only aggregate descendant text are not checked — axe checks
+ * the element that *directly* contains the rendered text, not every ancestor.
+ */
+function hasOwnTextNode(element: Element): boolean {
+  for (const node of element.childNodes) {
+    if (node.nodeType === Node.TEXT_NODE && node.textContent?.trim()) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -64,16 +110,13 @@ function shouldCheckContrast(element: Element): boolean {
     return false;
   }
 
-  // Check for text content
-  if (!hasTextContent(element)) {
+  // Only check elements that directly contain text — avoid double-flagging
+  // wrappers that aggregate descendant text via element.textContent.
+  if (!hasOwnTextNode(element)) {
     return false;
   }
 
-  // Check if element contains only images (text-as-image)
-  const hasOnlyImages =
-    element.children.length > 0 &&
-    [...element.children].every((child) => child.tagName === "IMG");
-  if (hasOnlyImages && !element.textContent?.trim()) {
+  if (!hasTextContent(element)) {
     return false;
   }
 

--- a/src/rules/focus-order-semantics.ts
+++ b/src/rules/focus-order-semantics.ts
@@ -117,6 +117,25 @@ function getRole(element: Element): string | null {
 }
 
 /**
+ * A scrollable region (overflow: auto/scroll) intentionally needs tabindex="0"
+ * so keyboard users can scroll it (WCAG 2.1 SC 2.1.1). Exempt these from the
+ * rule — axe-core has a separate `scrollable-region-focusable` check that
+ * *requires* the tabindex here.
+ */
+function isScrollableOverflow(value: string): boolean {
+  return value === "auto" || value === "scroll";
+}
+
+function isScrollableRegion(element: Element): boolean {
+  if (!(element instanceof HTMLElement)) return false;
+  const computed = globalThis.getComputedStyle(element);
+  return (
+    isScrollableOverflow(computed.overflowY) ||
+    isScrollableOverflow(computed.overflowX)
+  );
+}
+
+/**
  * Check if an element is in the focus order
  */
 function isInFocusOrder(element: Element): boolean {
@@ -194,6 +213,10 @@ export default function focusOrderSemantics(
   for (const el of elementsWithTabindex) {
     // Only check elements that are in the focus order
     if (!isInFocusOrder(el)) {
+      continue;
+    }
+
+    if (isScrollableRegion(el)) {
       continue;
     }
 

--- a/tests/color-contrast.test.ts
+++ b/tests/color-contrast.test.ts
@@ -184,6 +184,60 @@ describe("color-contrast", function () {
 
       expect(results).to.be.empty;
     });
+
+    it("does not flag wrappers that only aggregate descendant text", async () => {
+      // Decorative dot whose only "text" comes from a screen-reader-only span.
+      // Axe checks the element directly containing the text, not every ancestor.
+      const container = await fixture(
+        html`<div
+          style="background-color: oklch(0.546 0.245 262.881); width: 8px; height: 8px;"
+        >
+          <span
+            style="clip-path: inset(50%); position: absolute; width: 1px; height: 1px; overflow: hidden;"
+            >Click here to add devices</span
+          >
+        </div>`,
+      );
+      const results = await scanner.scan(container);
+
+      expect(results).to.be.empty;
+    });
+
+    it("skips screen-reader-only elements (clip-path: inset(50%))", async () => {
+      const container = await fixture(
+        html`<span
+          style="clip-path: inset(50%); position: absolute; width: 1px; height: 1px; overflow: hidden; color: rgb(150, 150, 150); background-color: rgb(255, 255, 255);"
+          >Screen reader only text</span
+        >`,
+      );
+      const results = await scanner.scan(container);
+
+      expect(results).to.be.empty;
+    });
+
+    it("skips screen-reader-only elements (clip: rect(0,0,0,0))", async () => {
+      const container = await fixture(
+        html`<span
+          style="clip: rect(0, 0, 0, 0); position: absolute; width: 1px; height: 1px; overflow: hidden; color: rgb(150, 150, 150); background-color: rgb(255, 255, 255);"
+          >Screen reader only text</span
+        >`,
+      );
+      const results = await scanner.scan(container);
+
+      expect(results).to.be.empty;
+    });
+
+    it("skips 1x1 absolutely-positioned overflow:hidden elements", async () => {
+      const container = await fixture(
+        html`<span
+          style="position: absolute; width: 1px; height: 1px; overflow: hidden; color: rgb(150, 150, 150); background-color: rgb(255, 255, 255);"
+          >Screen reader only text</span
+        >`,
+      );
+      const results = await scanner.scan(container);
+
+      expect(results).to.be.empty;
+    });
   });
 
   describe("handles edge cases", function () {
@@ -203,14 +257,14 @@ describe("color-contrast", function () {
     it("handles transparent background by inheriting from parent", async () => {
       const container = await fixture(
         html`<div style="background-color: rgb(0, 0, 0);">
-          <div style="color: rgb(150, 150, 150); background-color: transparent;">
+          <div style="color: rgb(50, 50, 50); background-color: transparent;">
             Text on transparent
           </div>
         </div>`,
       );
       const results = await scanner.scan(container);
 
-      // Against black background, gray text should have low contrast
+      // Dark gray text on (inherited) black background — low contrast.
       expect(results.length).to.be.greaterThan(0);
     });
 

--- a/tests/focus-order-semantics.test.ts
+++ b/tests/focus-order-semantics.test.ts
@@ -251,6 +251,43 @@ describe("focus-order-semantics", function () {
 
       expect(results).to.be.empty;
     });
+
+    it("scrollable region with tabindex='0' (overflow: auto)", async () => {
+      // Per WCAG 2.1 SC 2.1.1, scrollable regions need to be focusable so
+      // keyboard users can scroll them — axe has a separate rule that
+      // *requires* this and exempts these from focus-order-semantics.
+      const container = await fixture(
+        html`<div tabindex="0" style="overflow: auto; max-height: 200px;">
+          Scrollable content
+        </div>`,
+      );
+      const results = await scanner.scan(container);
+
+      expect(results).to.be.empty;
+    });
+
+    it("scrollable region with tabindex='0' (overflow-y: scroll)", async () => {
+      const container = await fixture(
+        html`<div
+          tabindex="0"
+          style="overflow-y: scroll; max-height: 200px;"
+        ></div>`,
+      );
+      const results = await scanner.scan(container);
+
+      expect(results).to.be.empty;
+    });
+
+    it("scrollable region with tabindex='0' (overflow-x: auto)", async () => {
+      const container = await fixture(
+        html`<div tabindex="0" style="overflow-x: auto; max-width: 200px;">
+          Wide content
+        </div>`,
+      );
+      const results = await scanner.scan(container);
+
+      expect(results).to.be.empty;
+    });
   });
 
   describe("edge cases", function () {


### PR DESCRIPTION
## Summary
Eliminates three false positives reported in real-world Tailwind UIs where axe-core stays silent:

- **color-contrast on wrapper elements** — `shouldCheckContrast` used `element.textContent`, which aggregates descendants, so a wrapper got contrast-checked against its own colors using text that lived in a child. Now only elements with a direct text-node child are checked, matching axe's behavior of testing the element that *directly* contains the text.
- **color-contrast on screen-reader-only text** — visibility heuristic only looked at `display`/`visibility`/`opacity`/bounding rect. Tailwind's `sr-only` (`clip-path: inset(50%); position: absolute; width: 1px; height: 1px; overflow: hidden`) slipped through. Added detection for `clip-path: inset(50%|100%)`, `clip: rect(0,0,0,0)`, and the 1×1 absolute + overflow:hidden fallback.
- **focus-order-semantics on scrollable regions** — `<div tabindex="0" class="overflow-auto max-h-96">` was flagged, but per WCAG 2.1 SC 2.1.1 a scrollable region **must** be keyboard-focusable so users can scroll it (axe-core has a separate `scrollable-region-focusable` rule that *requires* `tabindex="0"` here and exempts these from `focus-order-semantics`). Now skipped when `overflow-x|y` is `auto`/`scroll`.

## Test plan
- [x] `npm run format` (lint + types) clean
- [x] `npm test` — full suite passes
- [x] 4 new color-contrast tests: wrapper aggregating descendant text, three sr-only patterns
- [x] 3 new focus-order-semantics tests: `overflow: auto`, `overflow-y: scroll`, `overflow-x: auto`
- [x] Updated existing `handles transparent background by inheriting from parent` — was incidentally relying on the wrapper false positive (rgb(150,150,150) on black is ~7:1, not low contrast); now uses rgb(50,50,50) so the assertion is genuine

🤖 Generated with [Claude Code](https://claude.com/claude-code)