### PR TITLE
Recognize media-fragment duration in no-autoplay-audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The W3C [ACT implementations report](https://www.w3.org/WAI/standards-guidelines
 - **14** ACT rules pass every generated test case (W3C "consistent implementation" criterion).
 - **16** more rules pass at least one test case but not all.
 - **53 / 88** ACT rules have some scanner implementation, even if untested.
-- **242 / 843** ACT test cases (29%) are exercised against the scanner.
+- **243 / 843** ACT test cases (29%) are exercised against the scanner.
 
 | Implemented | ACT Rule                                                                                                                                         | WCAG                | axe-core rule(s)                                                          | Test cases |
 | :---------- | :----------------------------------------------------------------------------------------------------------------------------------------------- | :------------------ | :------------------------------------------------------------------------ | :--------- |
@@ -26,7 +26,7 @@ The W3C [ACT implementations report](https://www.w3.org/WAI/standards-guidelines
 | ❌          | [e7aa44](https://act-rules.github.io/rules/e7aa44) — Audio element content has text alternative                                                  | 1.2.1               | —                                                                         | 0 / 5      |
 | ✅          | [2eb176](https://act-rules.github.io/rules/2eb176) — Audio element content has transcript                                                        | —                   | `audio-caption`                                                           | 0 / 9      |
 | ✅          | [afb423](https://act-rules.github.io/rules/afb423) — Audio element content is media alternative for text                                         | —                   | `audio-caption`                                                           | 0 / 5      |
-| ✅          | [80f0bf](https://act-rules.github.io/rules/80f0bf) — Audio or video element avoids automatically playing audio                                   | 1.4.2               | `no-autoplay-audio`                                                       | 3 / 5      |
+| ✅          | [80f0bf](https://act-rules.github.io/rules/80f0bf) — Audio or video element avoids automatically playing audio                                   | 1.4.2               | `no-autoplay-audio`                                                       | 4 / 5      |
 | ❌          | [4c31df](https://act-rules.github.io/rules/4c31df) — Audio or video element that plays automatically has a control mechanism                     | —                   | —                                                                         | 0 / 8      |
 | ❌          | [aaa1bf](https://act-rules.github.io/rules/aaa1bf) — Audio or video element that plays automatically has no audio that lasts more than 3 seconds | —                   | —                                                                         | 0 / 4      |
 | ✅          | [3e12e1](https://act-rules.github.io/rules/3e12e1) — Block of repeated content is collapsible                                                    | —                   | `bypass`                                                                  | 3 / 7      |

--- a/generate-act-tests.js
+++ b/generate-act-tests.js
@@ -228,9 +228,6 @@ const skippedExamples = [
   // [e88epe] decorative-image: scanner does not analyse canvas visual content
   "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/e88epe/6d108d00cc7a54f66547f02d7e7606342b11f801.html",
 
-  // [80f0bf] no-autoplay-audio: scanner can't detect short media duration from URL fragment (#t=8,10)
-  "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/80f0bf/e4d78b5074773ab0cbd8c72732e948c4608f5c9d.html",
-
   // [80f0bf] no-autoplay-audio: scanner can't detect JavaScript-based control mechanisms
   "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/80f0bf/29ea904ef03f14401a7b43a5ffc9b30271697bc7.html",
 

--- a/src/rules/no-autoplay-audio.ts
+++ b/src/rules/no-autoplay-audio.ts
@@ -7,6 +7,50 @@ const text =
 const url = `https://dequeuniversity.com/rules/axe/4.11/${id}`;
 const MAX_ALLOWED_DURATION_SECONDS = 3;
 
+// Parse a Media Fragments URI temporal range from a URL fragment, e.g.
+// "video.mp4#t=8,10". Returns the playback duration cap in seconds when both
+// start and end are provided, or `null` when the fragment doesn't bound the
+// playback length (open-ended, malformed, or absent).
+function durationFromMediaFragment(src: string | null): number | null {
+  if (!src) return null;
+  const hashIdx = src.indexOf("#");
+  if (hashIdx === -1) return null;
+  for (const param of src.slice(hashIdx + 1).split("&")) {
+    if (!param.startsWith("t=")) continue;
+    const [startStr, endStr] = param.slice(2).split(",");
+    if (endStr === undefined) return null;
+    const start = startStr === "" ? 0 : parseFloat(startStr);
+    const end = parseFloat(endStr);
+    if (isNaN(start) || isNaN(end)) return null;
+    return Math.max(0, end - start);
+  }
+  return null;
+}
+
+function getEffectiveDuration(
+  el: HTMLAudioElement | HTMLVideoElement,
+): number | null {
+  if (el.duration > 0 && !isNaN(el.duration)) return el.duration;
+
+  const srcs: string[] = [];
+  const ownSrc = el.getAttribute("src");
+  if (ownSrc) srcs.push(ownSrc);
+  for (const source of el.querySelectorAll<HTMLSourceElement>("source")) {
+    const s = source.getAttribute("src");
+    if (s) srcs.push(s);
+  }
+  if (srcs.length === 0) return null;
+
+  let maxDuration = 0;
+  for (const src of srcs) {
+    const dur = durationFromMediaFragment(src);
+    // If any source lacks a bounded fragment we can't prove the clip is short.
+    if (dur === null) return null;
+    if (dur > maxDuration) maxDuration = dur;
+  }
+  return maxDuration;
+}
+
 function hasAutoplayViolation(
   el: HTMLAudioElement | HTMLVideoElement,
 ): boolean {
@@ -25,10 +69,10 @@ function hasAutoplayViolation(
     return false;
   }
 
-  // If duration is 3 seconds or less, it's okay
-  // Note: duration might not be available until metadata is loaded
-  // For static analysis, we need to flag it as needing review
-  if (el.duration > 0 && el.duration <= MAX_ALLOWED_DURATION_SECONDS) {
+  // If duration is 3 seconds or less, it's okay. Falls back to the temporal
+  // media fragment range when metadata-derived duration is unavailable.
+  const duration = getEffectiveDuration(el);
+  if (duration !== null && duration <= MAX_ALLOWED_DURATION_SECONDS) {
     return false;
   }
 

--- a/tests/act/tests/80f0bf/e4d78b5074773ab0cbd8c72732e948c4608f5c9d.ts
+++ b/tests/act/tests/80f0bf/e4d78b5074773ab0cbd8c72732e948c4608f5c9d.ts
@@ -4,7 +4,7 @@ import { scan } from "../../../../src/scanner";
 const parser = new DOMParser();
 
 describe("[80f0bf]Audio or video element avoids automatically playing audio", function () {
-  it.skip("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/80f0bf/e4d78b5074773ab0cbd8c72732e948c4608f5c9d.html)", async () => {
+  it("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/80f0bf/e4d78b5074773ab0cbd8c72732e948c4608f5c9d.html)", async () => {
     const document = parser.parseFromString(`<!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Summary
- 80f0bf Passed Example 2 autoplays a video whose `<source>` URLs end in `#t=8,10` — a Media Fragments URI temporal range bounding playback to 2 seconds, under ACT's 3-second exemption. The scanner only consulted `el.duration`, which is `NaN` under DOMParser, so the test was skipped.
- Parse the `#t=start,end` fragment from `src` and from `<source>` children. Apply the exemption only when every source has a bounded range and the longest is ≤3s; otherwise fall back to the existing behavior so open-ended sources still fail.

80f0bf: 3/5 → 4/5. The remaining skip (Passed Example 3) needs JS execution to evaluate script-based controls.

Refs #413.

## Test plan
- [x] `npm test` (399 files passing)
- [x] `npm run build:readme` — counts refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)