### PR TITLE
Move 2779a5 ACT rule to consistently implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Implementation status against the [ACT Rules Community Group](https://act-rules.
 
 The W3C [ACT implementations report](https://www.w3.org/WAI/standards-guidelines/act/implementations/) only counts a rule as "consistently implemented" when the implementation passes every published ACT test case for it. By that measure:
 
-- **17** ACT rules pass every generated test case (W3C "consistent implementation" criterion).
+- **18** ACT rules pass every generated test case (W3C "consistent implementation" criterion).
 - **14** more rules pass at least one test case but not all.
 - **53 / 88** ACT rules have some scanner implementation, even if untested.
-- **263 / 843** ACT test cases (31%) are exercised against the scanner.
+- **275 / 843** ACT test cases (33%) are exercised against the scanner.
 
 | Implemented | ACT Rule                                                                                                                                         | WCAG                | axe-core rule(s)                                                          | Test cases |
 | :---------- | :----------------------------------------------------------------------------------------------------------------------------------------------- | :------------------ | :------------------------------------------------------------------------ | :--------- |
@@ -57,7 +57,7 @@ The W3C [ACT implementations report](https://www.w3.org/WAI/standards-guidelines
 | ❌          | [0va7u6](https://act-rules.github.io/rules/0va7u6) — HTML images contain no text                                                                 | 1.4.5, 1.4.9        | —                                                                         | 0 / 13     |
 | ✅          | [bf051a](https://act-rules.github.io/rules/bf051a) — HTML page `lang` attribute has valid language tag                                           | 3.1.1               | `html-lang-valid`                                                         | 6 / 6      |
 | ✅          | [b5c3f8](https://act-rules.github.io/rules/b5c3f8) — HTML page has lang attribute                                                                | 3.1.1               | `html-has-lang`                                                           | 5 / 5      |
-| ✅          | [2779a5](https://act-rules.github.io/rules/2779a5) — HTML page has non-empty title                                                               | 2.4.2               | `document-title`                                                          | 0 / 12     |
+| ✅          | [2779a5](https://act-rules.github.io/rules/2779a5) — HTML page has non-empty title                                                               | 2.4.2               | `document-title`                                                          | 12 / 12    |
 | ❌          | [ucwvc8](https://act-rules.github.io/rules/ucwvc8) — HTML page language subtag matches default language                                          | 3.1.1               | —                                                                         | 0 / 9      |
 | ❌          | [c4a8a4](https://act-rules.github.io/rules/c4a8a4) — HTML page title is descriptive                                                              | 2.4.2               | —                                                                         | 0 / 6      |
 | ✅          | [cae760](https://act-rules.github.io/rules/cae760) — Iframe element has non-empty accessible name                                                | 4.1.2               | `frame-title`                                                             | 0 / 7      |

--- a/generate-act-tests.js
+++ b/generate-act-tests.js
@@ -143,7 +143,6 @@ const rulesToIgnore = [
   "cc0f0a", // Form field label is descriptive - not implemented, requires human judgment
 
   // --- Not implemented - page-level and structural rules ---
-  "2779a5", // HTML page has non-empty title - not implemented in ACT test format
   "off6ek", // HTML element language subtag matches language - not implemented
   "ucwvc8", // HTML page language subtag matches default language - not implemented
   "c4a8a4", // HTML page title is descriptive - not implemented, requires human judgment
@@ -279,6 +278,7 @@ const skippedExamples = [
 // as input, because they perform page-level checks.
 const rulesRequiringDocumentElement = [
   "047fe0", // Document has heading
+  "2779a5", // HTML page has non-empty title (lives in <head>)
   "3e12e1", // Block of repeated content is collapsible
   "bc659a", // Meta element has no refresh delay (lives in <head>)
   "bisz58", // Meta element has no refresh delay, no exception (lives in <head>)

--- a/src/rules/document-title.ts
+++ b/src/rules/document-title.ts
@@ -5,28 +5,19 @@ const text = "Documents must have <title> element to aid in navigation";
 const url = `https://dequeuniversity.com/rules/axe/4.11/${id}`;
 
 export default function (element: Element): AccessibilityError[] {
-  if (!element) {
-    return [];
-  }
   const document = element.ownerDocument;
-  if (!document) {
-    return [];
-  }
-  const titleElements = document.querySelectorAll("title");
+  if (!document) return [];
 
-  // Check if there is at least one <title> element
-  if (titleElements.length === 0) {
+  // ACT 2779a5 considers only the first <title> in document order — a later
+  // non-empty <title> can't compensate for an empty first one.
+  const firstTitle = document.querySelector("title");
+  if (!firstTitle) {
     return [{ id, element: document.documentElement, url, text }];
   }
 
-  // Check that at least one <title> element has non-empty text content
-  for (const titleElement of titleElements) {
-    const titleText = titleElement.textContent?.trim();
-    if (titleText && titleText.length > 0) {
-      return [];
-    }
+  if ((firstTitle.textContent ?? "").trim().length === 0) {
+    return [{ id, element: document.documentElement, url, text }];
   }
 
-  // All <title> elements are empty
-  return [{ id, element: document.documentElement, url, text }];
+  return [];
 }

--- a/tests/act/tests/2779a5/0ad882dffaf6edd16058119e1c513b4746b0ac27.ts
+++ b/tests/act/tests/2779a5/0ad882dffaf6edd16058119e1c513b4746b0ac27.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2779a5]HTML page has non-empty title", function () {
+  it("Passed Example 5 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2779a5/0ad882dffaf6edd16058119e1c513b4746b0ac27.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title>Title of the page.</title>
+	</head>
+	<body>
+		<title></title>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.documentElement)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/document-title"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/2779a5/314d991fa5328e41f8a806bfbac84d748b41f7ed.ts
+++ b/tests/act/tests/2779a5/314d991fa5328e41f8a806bfbac84d748b41f7ed.ts
@@ -1,0 +1,21 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2779a5]HTML page has non-empty title", function () {
+  it("Failed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2779a5/314d991fa5328e41f8a806bfbac84d748b41f7ed.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<title></title>
+</html>`, 'text/html');
+
+    const results = (await scan(document.documentElement)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/document-title"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/2779a5/4eeff9c95f15e90ca5abc972079112d1ea5c3d51.ts
+++ b/tests/act/tests/2779a5/4eeff9c95f15e90ca5abc972079112d1ea5c3d51.ts
@@ -1,0 +1,21 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2779a5]HTML page has non-empty title", function () {
+  it("Failed Example 5 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2779a5/4eeff9c95f15e90ca5abc972079112d1ea5c3d51.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<title> </title>
+</html>`, 'text/html');
+
+    const results = (await scan(document.documentElement)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/document-title"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/2779a5/5fd6fda771cf8810eef5166464622d6979e0406e.ts
+++ b/tests/act/tests/2779a5/5fd6fda771cf8810eef5166464622d6979e0406e.ts
@@ -1,0 +1,21 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2779a5]HTML page has non-empty title", function () {
+  it("Failed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2779a5/5fd6fda771cf8810eef5166464622d6979e0406e.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<iframe src="/WAI/content-assets/wcag-act-rules/test-assets/sc2-4-2-title-page-with-title.html"></iframe>
+</html>`, 'text/html');
+
+    const results = (await scan(document.documentElement)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/document-title"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/2779a5/64771c390e57375a822a7223362ea7bb859c0a96.ts
+++ b/tests/act/tests/2779a5/64771c390e57375a822a7223362ea7bb859c0a96.ts
@@ -1,0 +1,22 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2779a5]HTML page has non-empty title", function () {
+  it("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2779a5/64771c390e57375a822a7223362ea7bb859c0a96.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<title>This page gives a title to an iframe</title>
+	<iframe src="/WAI/content-assets/wcag-act-rules/test-assets/sc2-4-2-title-page-without-title.html"></iframe>
+</html>`, 'text/html');
+
+    const results = (await scan(document.documentElement)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/document-title"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/2779a5/6b3d2e2147cfc618b744f2dabfaf2e66327055d7.ts
+++ b/tests/act/tests/2779a5/6b3d2e2147cfc618b744f2dabfaf2e66327055d7.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2779a5]HTML page has non-empty title", function () {
+  it("Passed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2779a5/6b3d2e2147cfc618b744f2dabfaf2e66327055d7.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title>Title of the page.</title>
+	</head>
+	<body>
+		<title>Title of the page.</title>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.documentElement)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/document-title"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/2779a5/7f9f315b5041f3726662bf269613c43678af99d4.ts
+++ b/tests/act/tests/2779a5/7f9f315b5041f3726662bf269613c43678af99d4.ts
@@ -1,0 +1,21 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2779a5]HTML page has non-empty title", function () {
+  it("Passed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2779a5/7f9f315b5041f3726662bf269613c43678af99d4.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<title>This page has a title</title>
+</html>`, 'text/html');
+
+    const results = (await scan(document.documentElement)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/document-title"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/2779a5/820fb18c9bb20fb1a940a0806a87c6f6e468bb5b.ts
+++ b/tests/act/tests/2779a5/820fb18c9bb20fb1a940a0806a87c6f6e468bb5b.ts
@@ -1,0 +1,21 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2779a5]HTML page has non-empty title", function () {
+  it("Failed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2779a5/820fb18c9bb20fb1a940a0806a87c6f6e468bb5b.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<h1>this page has no title</h1>
+</html>`, 'text/html');
+
+    const results = (await scan(document.documentElement)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/document-title"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/2779a5/94ff40484422832c2910086d4387163aa2d9dd7d.ts
+++ b/tests/act/tests/2779a5/94ff40484422832c2910086d4387163aa2d9dd7d.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2779a5]HTML page has non-empty title", function () {
+  it("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2779a5/94ff40484422832c2910086d4387163aa2d9dd7d.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title>This page gives a title to an iframe</title>
+	</head>
+	<body>
+		<iframe src="/WAI/content-assets/wcag-act-rules/test-assets/sc2-4-2-title-page-without-title.html"></iframe>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.documentElement)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/document-title"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/2779a5/9c5eeb535181f3709e13b548a04b9d0054532cdd.ts
+++ b/tests/act/tests/2779a5/9c5eeb535181f3709e13b548a04b9d0054532cdd.ts
@@ -1,0 +1,32 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2779a5]HTML page has non-empty title", function () {
+  it("Failed Example 6 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2779a5/9c5eeb535181f3709e13b548a04b9d0054532cdd.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<body>
+		<template id="shadow-element">
+			<title>This is the page title</title>
+		</template>
+		<script>
+			const host = document.querySelector('body')
+			const shadow = host.attachShadow({ mode: 'open' })
+			const template = document.getElementById('shadow-element')
+
+			shadow.appendChild(template.content)
+		</script>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.documentElement)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/document-title"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/2779a5/a14968698b0e95b6624f187d4538e320e4fa8952.ts
+++ b/tests/act/tests/2779a5/a14968698b0e95b6624f187d4538e320e4fa8952.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2779a5]HTML page has non-empty title", function () {
+  it("Failed Example 4 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2779a5/a14968698b0e95b6624f187d4538e320e4fa8952.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title></title>
+	</head>
+	<body>
+		<title>Title of the page.</title>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.documentElement)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/document-title"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/2779a5/efa1e0438bb515332ec6b4d943044c336ca77fab.ts
+++ b/tests/act/tests/2779a5/efa1e0438bb515332ec6b4d943044c336ca77fab.ts
@@ -1,0 +1,23 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[2779a5]HTML page has non-empty title", function () {
+  it("Passed Example 4 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/2779a5/efa1e0438bb515332ec6b4d943044c336ca77fab.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<body>
+		<title>Title of the page.</title>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.documentElement)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/document-title"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});


### PR DESCRIPTION
## Summary
The document-title rule was gated in `rulesToIgnore` even though the implementation was nearly there. Two issues held it back:
- The generated tests scan `document.body`, but `<title>` lives in `<head>` — so the rule had nothing to inspect.
- The rule passed if *any* `<title>` had non-empty text. ACT 2779a5 only considers the first `<title>` in document order; a later one cannot compensate for an empty first one.

Scoped the rule to the first `<title>` and added `2779a5` to `rulesRequiringDocumentElement` so generated tests scan `document.documentElement`.

2779a5: 0 → 12/12 (moved from "zero" to "consistent"). README counts refreshed.

Refs #413.

## Test plan
- [x] `npm test` (411 files passing)
- [x] `npm run build:readme`

🤖 Generated with [Claude Code](https://claude.com/claude-code)