### PR TITLE
Move b4f0c3 ACT rule to consistently implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Implementation status against the [ACT Rules Community Group](https://act-rules.
 
 The W3C [ACT implementations report](https://www.w3.org/WAI/standards-guidelines/act/implementations/) only counts a rule as "consistently implemented" when the implementation passes every published ACT test case for it. By that measure:
 
-- **18** ACT rules pass every generated test case (W3C "consistent implementation" criterion).
+- **19** ACT rules pass every generated test case (W3C "consistent implementation" criterion).
 - **14** more rules pass at least one test case but not all.
 - **53 / 88** ACT rules have some scanner implementation, even if untested.
-- **275 / 843** ACT test cases (33%) are exercised against the scanner.
+- **287 / 843** ACT test cases (34%) are exercised against the scanner.
 
 | Implemented | ACT Rule                                                                                                                                         | WCAG                | axe-core rule(s)                                                          | Test cases |
 | :---------- | :----------------------------------------------------------------------------------------------------------------------------------------------- | :------------------ | :------------------------------------------------------------------------ | :--------- |
@@ -79,7 +79,7 @@ The W3C [ACT implementations report](https://www.w3.org/WAI/standards-guidelines
 | ✅          | [m6b1q3](https://act-rules.github.io/rules/m6b1q3) — Menuitem has non-empty accessible name                                                      | 4.1.2               | `button-name`                                                             | 6 / 6      |
 | ✅          | [bc659a](https://act-rules.github.io/rules/bc659a) — Meta element has no refresh delay                                                           | 2.2.1, 2.2.4, 3.2.5 | `meta-refresh`                                                            | 7 / 7      |
 | ✅          | [bisz58](https://act-rules.github.io/rules/bisz58) — Meta element has no refresh delay (no exception)                                            | 2.2.1, 2.2.4, 3.2.5 | `meta-refresh-no-exceptions`                                              | 5 / 5      |
-| ✅          | [b4f0c3](https://act-rules.github.io/rules/b4f0c3) — Meta viewport allows for zoom                                                               | 1.4.10, 1.4.4       | `meta-viewport`                                                           | 0 / 12     |
+| ✅          | [b4f0c3](https://act-rules.github.io/rules/b4f0c3) — Meta viewport allows for zoom                                                               | 1.4.10, 1.4.4       | `meta-viewport`                                                           | 12 / 12    |
 | ❌          | [ffbc54](https://act-rules.github.io/rules/ffbc54) — No keyboard shortcut uses only printable characters                                         | 2.1.4               | —                                                                         | 0 / 8      |
 | ✅          | [8fc3b6](https://act-rules.github.io/rules/8fc3b6) — Object element rendering non-text content has non-empty accessible name                     | 1.1.1               | `object-alt`                                                              | 10 / 10    |
 | ✅          | [b33eff](https://act-rules.github.io/rules/b33eff) — Orientation of the page is not restricted using CSS transforms                              | 1.3.4               | `css-orientation-lock`                                                    | 0 / 7      |

--- a/generate-act-tests.js
+++ b/generate-act-tests.js
@@ -152,7 +152,6 @@ const rulesToIgnore = [
 
   // --- Not implemented - various other rules ---
   "73f2c2", // Autocomplete attribute has valid value - not implemented in ACT test format
-  "b4f0c3", // Meta viewport allows for zoom - not implemented in ACT test format
   "4b1c6c", // Iframe elements with identical accessible names have equivalent purpose - not implemented
   "b49b2e", // Heading is descriptive - not implemented, requires human judgment
   "9bd38c", // Content has alternative for visual reference - not implemented, requires human judgment

--- a/src/rules/meta-viewport.ts
+++ b/src/rules/meta-viewport.ts
@@ -46,15 +46,16 @@ export default function metaViewport(element: Element) {
     const maxScale = content["maximum-scale"];
     if (maxScale !== undefined) {
       const maxScaleNum = Number.parseFloat(maxScale);
-      // Only flag valid positive numeric values that are less than 2.
-      // Non-numeric values (NaN) and negative values don't restrict zooming.
-      if (!Number.isNaN(maxScaleNum) && maxScaleNum >= 0 && maxScaleNum < 2) {
-        errors.push({
-          id,
-          element,
-          text,
-          url,
-        });
+      if (Number.isNaN(maxScaleNum)) {
+        // Non-numeric values restrict zoom (browsers fall back to 1.0)
+        // except `device-width`/`device-height`, which resolve to the
+        // device's pixel dimensions and effectively allow unrestricted zoom.
+        if (maxScale !== "device-width" && maxScale !== "device-height") {
+          errors.push({ id, element, text, url });
+        }
+      } else if (maxScaleNum >= 0 && maxScaleNum < 2) {
+        // Negative numbers are invalid and ignored by browsers (default >=2).
+        errors.push({ id, element, text, url });
       }
     }
   }

--- a/tests/act/tests/b4f0c3/08e8943b849762eb7f18654c7f9e479ad33b2840.ts
+++ b/tests/act/tests/b4f0c3/08e8943b849762eb7f18654c7f9e479ad33b2840.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[b4f0c3]Meta viewport allows for zoom", function () {
+  it("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/b4f0c3/08e8943b849762eb7f18654c7f9e479ad33b2840.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title>Simple page showing random text</title>
+		<meta name="viewport" content="user-scalable=5" />
+	</head>
+	<body>
+		<p>
+			Lorem ipsum
+		</p>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/meta-viewport"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/b4f0c3/30b40365b4e59aa103ff04c369f31658fa6e2790.ts
+++ b/tests/act/tests/b4f0c3/30b40365b4e59aa103ff04c369f31658fa6e2790.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[b4f0c3]Meta viewport allows for zoom", function () {
+  it("Passed Example 5 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/b4f0c3/30b40365b4e59aa103ff04c369f31658fa6e2790.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title>Simple page showing random text</title>
+		<meta name="viewport" content="maximum-scale=device-width" />
+	</head>
+	<body>
+		<p>
+			Lorem ipsum
+		</p>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/meta-viewport"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/b4f0c3/312146d84331c7214ed6919391ad955098eff516.ts
+++ b/tests/act/tests/b4f0c3/312146d84331c7214ed6919391ad955098eff516.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[b4f0c3]Meta viewport allows for zoom", function () {
+  it("Passed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/b4f0c3/312146d84331c7214ed6919391ad955098eff516.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title>Simple page showing random text</title>
+		<meta name="viewport" content="user-scalable=yes" />
+	</head>
+	<body>
+		<p>
+			Lorem ipsum
+		</p>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/meta-viewport"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/b4f0c3/4ade33e41dda291c9078e56ca2a95c4825dbc1fe.ts
+++ b/tests/act/tests/b4f0c3/4ade33e41dda291c9078e56ca2a95c4825dbc1fe.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[b4f0c3]Meta viewport allows for zoom", function () {
+  it("Passed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/b4f0c3/4ade33e41dda291c9078e56ca2a95c4825dbc1fe.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title>Simple page showing random text</title>
+		<meta name="viewport" content="maximum-scale=-1" />
+	</head>
+	<body>
+		<p>
+			Lorem ipsum
+		</p>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/meta-viewport"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/b4f0c3/8735b02e59dd802a5a9e9a7ea1934a106d2963eb.ts
+++ b/tests/act/tests/b4f0c3/8735b02e59dd802a5a9e9a7ea1934a106d2963eb.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[b4f0c3]Meta viewport allows for zoom", function () {
+  it("Failed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/b4f0c3/8735b02e59dd802a5a9e9a7ea1934a106d2963eb.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title>Simple page showing random text</title>
+		<meta name="viewport" content="user-scalable=0.5" />
+	</head>
+	<body>
+		<p>
+			Lorem ipsum
+		</p>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/meta-viewport"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/b4f0c3/9f288c284df9ade53aa33e50ec50c879d5aba4ef.ts
+++ b/tests/act/tests/b4f0c3/9f288c284df9ade53aa33e50ec50c879d5aba4ef.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[b4f0c3]Meta viewport allows for zoom", function () {
+  it("Failed Example 7 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/b4f0c3/9f288c284df9ade53aa33e50ec50c879d5aba4ef.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title>Simple page showing random text</title>
+		<meta name="viewport" content="maximum-scale=invalid" />
+	</head>
+	<body>
+		<p>
+			Lorem ipsum
+		</p>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/meta-viewport"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/b4f0c3/a1240b31761f65c92a8f6d08ed7105ee822d0ebc.ts
+++ b/tests/act/tests/b4f0c3/a1240b31761f65c92a8f6d08ed7105ee822d0ebc.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[b4f0c3]Meta viewport allows for zoom", function () {
+  it("Failed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/b4f0c3/a1240b31761f65c92a8f6d08ed7105ee822d0ebc.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title>Simple page showing random text</title>
+		<meta name="viewport" content="user-scalable=yes, initial-scale=0.8, maximum-scale=1.5" />
+	</head>
+	<body>
+		<p>
+			Lorem ipsum
+		</p>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/meta-viewport"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/b4f0c3/accc6adf094723693593ca3c6308f81945930dae.ts
+++ b/tests/act/tests/b4f0c3/accc6adf094723693593ca3c6308f81945930dae.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[b4f0c3]Meta viewport allows for zoom", function () {
+  it("Failed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/b4f0c3/accc6adf094723693593ca3c6308f81945930dae.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title>Simple page showing random text</title>
+		<meta name="viewport" content="user-scalable=no" />
+	</head>
+	<body>
+		<p>
+			Lorem ipsum
+		</p>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/meta-viewport"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/b4f0c3/c7e4980eb42d0b138684ac1e28318a197d86ccfc.ts
+++ b/tests/act/tests/b4f0c3/c7e4980eb42d0b138684ac1e28318a197d86ccfc.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[b4f0c3]Meta viewport allows for zoom", function () {
+  it("Failed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/b4f0c3/c7e4980eb42d0b138684ac1e28318a197d86ccfc.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title>Simple page showing random text</title>
+		<meta name="viewport" content="maximum-scale=1.0" />
+	</head>
+	<body>
+		<p>
+			Lorem ipsum
+		</p>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/meta-viewport"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/b4f0c3/c94a59f8c3b17d722781af36da3556ff4b418776.ts
+++ b/tests/act/tests/b4f0c3/c94a59f8c3b17d722781af36da3556ff4b418776.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[b4f0c3]Meta viewport allows for zoom", function () {
+  it("Failed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/b4f0c3/c94a59f8c3b17d722781af36da3556ff4b418776.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title>Simple page showing random text</title>
+		<meta name="viewport" content="user-scalable=invalid" />
+	</head>
+	<body>
+		<p>
+			Lorem ipsum
+		</p>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/meta-viewport"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/b4f0c3/d143bfe343ecf75bceb92b6fc9807cc5f453b319.ts
+++ b/tests/act/tests/b4f0c3/d143bfe343ecf75bceb92b6fc9807cc5f453b319.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[b4f0c3]Meta viewport allows for zoom", function () {
+  it("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/b4f0c3/d143bfe343ecf75bceb92b6fc9807cc5f453b319.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title>Simple page showing random text</title>
+		<meta name="viewport" content="maximum-scale=2.0" />
+	</head>
+	<body>
+		<p>
+			Lorem ipsum
+		</p>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/meta-viewport"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/b4f0c3/e5695989a43a3297cf6b78182014c7a3848ff7e1.ts
+++ b/tests/act/tests/b4f0c3/e5695989a43a3297cf6b78182014c7a3848ff7e1.ts
@@ -1,0 +1,29 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[b4f0c3]Meta viewport allows for zoom", function () {
+  it("Failed Example 4 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/b4f0c3/e5695989a43a3297cf6b78182014c7a3848ff7e1.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html>
+	<head>
+		<title>Simple page showing random text</title>
+		<meta name="viewport" content="maximum-scale=yes" />
+	</head>
+	<body>
+		<p>
+			Lorem ipsum
+		</p>
+	</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/meta-viewport"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
The `meta-viewport` rule treated all non-numeric `maximum-scale` values as "doesn't restrict zoom", but ACT b4f0c3 expects strings like `yes` or `invalid` to fail — browsers fall back to the 1.0 default, restricting zoom. Only `device-width` / `device-height` legitimately resolve to large values.

Tighten the maximum-scale handling: numeric values keep their existing semantics; non-numeric tokens fail unless they are `device-width` or `device-height`. The user-scalable handling already matched the spec.

b4f0c3: 0 → 12/12 (zero → consistent).

Refs #413.

## Test plan
- [x] `npm test`
- [x] `npm run build:readme`

🤖 Generated with [Claude Code](https://claude.com/claude-code)