### PR TITLE
CI: use PAT for auto-commit push so follow-up workflows fire

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ jobs:
           # On PRs, check out the head ref directly (not the merge commit) so
           # any regenerated files can be pushed back to the source branch.
           ref: ${{ github.head_ref || github.ref }}
+          # Use a PAT (when configured) so the auto-commit push triggers a
+          # follow-up CI run. Pushes authenticated with the default
+          # GITHUB_TOKEN deliberately don't trigger workflows, which leaves
+          # PRs stuck without status checks on the regenerated commit. Falls
+          # back to GITHUB_TOKEN on forks where the secret is unavailable.
+          token: ${{ secrets.CI_AUTOCOMMIT_PAT || secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v6
         with:
           node-version: 22


### PR DESCRIPTION
## Summary
GitHub deliberately does not trigger workflow runs from pushes authenticated with the default `GITHUB_TOKEN` (anti-recursion guard). The result is that the auto-commit step in CI ("Sync ACT testcases and regenerate tests / README") leaves PRs stuck without status checks on the regenerated commit — see #418, where the bot's auto-commit shows no CI run and the PR is `BLOCKED` on required checks.

Wire `actions/checkout` to use `secrets.CI_AUTOCOMMIT_PAT` when present, falling back to `GITHUB_TOKEN` otherwise. A PAT-authored push will trigger the workflow on the new SHA so required checks resolve. Forks lack the secret and keep using `GITHUB_TOKEN`, but the auto-commit step is already gated to same-repo PRs (`head.repo.full_name == github.repository`), so they aren't affected either way.

## Setup needed before merging
Create a **fine-grained PAT** scoped to this repo with **Contents: Read and write** permission, then add it to the repo's Actions secrets as `CI_AUTOCOMMIT_PAT`.

Once the secret exists, any PR whose CI auto-commits regenerated files will get a fresh CI run on the bot's commit and unblock its checks.

## Test plan
- [ ] Set up `CI_AUTOCOMMIT_PAT` secret on the repo.
- [ ] Merge this PR.
- [ ] Verify a future PR with regen-needed files shows two CI runs (one on the original commit, one on the auto-commit) both completing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)