### PR TITLE
Move ffd0e9 ACT rule to consistently implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Implementation status against the [ACT Rules Community Group](https://act-rules.
 
 The W3C [ACT implementations report](https://www.w3.org/WAI/standards-guidelines/act/implementations/) only counts a rule as "consistently implemented" when the implementation passes every published ACT test case for it. By that measure:
 
-- **16** ACT rules pass every generated test case (W3C "consistent implementation" criterion).
+- **17** ACT rules pass every generated test case (W3C "consistent implementation" criterion).
 - **14** more rules pass at least one test case but not all.
 - **53 / 88** ACT rules have some scanner implementation, even if untested.
-- **250 / 843** ACT test cases (30%) are exercised against the scanner.
+- **263 / 843** ACT test cases (31%) are exercised against the scanner.
 
 | Implemented | ACT Rule                                                                                                                                         | WCAG                | axe-core rule(s)                                                          | Test cases |
 | :---------- | :----------------------------------------------------------------------------------------------------------------------------------------------- | :------------------ | :------------------------------------------------------------------------ | :--------- |
@@ -51,7 +51,7 @@ The W3C [ACT implementations report](https://www.w3.org/WAI/standards-guidelines
 | ✅          | [e086e5](https://act-rules.github.io/rules/e086e5) — Form field has non-empty accessible name                                                    | 1.3.1, 2.5.3, 4.1.2 | `aria-input-field-name`, `aria-toggle-field-name`, `label`, `select-name` | 19 / 19    |
 | ❌          | [cc0f0a](https://act-rules.github.io/rules/cc0f0a) — Form field label is descriptive                                                             | 2.4.6               | —                                                                         | 0 / 13     |
 | ✅          | [a25f45](https://act-rules.github.io/rules/a25f45) — Headers attribute specified on a cell refers to cells in the same table element             | 1.3.1               | `td-headers-attr`                                                         | 12 / 12    |
-| ✅          | [ffd0e9](https://act-rules.github.io/rules/ffd0e9) — Heading has non-empty accessible name                                                       | —                   | `empty-heading`                                                           | 0 / 13     |
+| ✅          | [ffd0e9](https://act-rules.github.io/rules/ffd0e9) — Heading has non-empty accessible name                                                       | —                   | `empty-heading`                                                           | 13 / 13    |
 | ❌          | [b49b2e](https://act-rules.github.io/rules/b49b2e) — Heading is descriptive                                                                      | 2.4.6               | —                                                                         | 0 / 10     |
 | ❌          | [off6ek](https://act-rules.github.io/rules/off6ek) — HTML element language subtag matches language                                               | 3.1.2               | —                                                                         | 0 / 9      |
 | ❌          | [0va7u6](https://act-rules.github.io/rules/0va7u6) — HTML images contain no text                                                                 | 1.4.5, 1.4.9        | —                                                                         | 0 / 13     |

--- a/generate-act-tests.js
+++ b/generate-act-tests.js
@@ -306,9 +306,11 @@ for (const rule of applicableRules) {
 
   console.log({ ruleId, testcaseId });
 
+  // Accept WCAG-mapped requirements and ARIA name-calculation requirements
+  // (ARIA 1.2 §5.2.8 corresponds to WCAG SC 4.1.2 Name, Role, Value).
   if (
     Object.keys(ruleAccessibilityRequirements).every(
-      (x) => !x.startsWith("wcag"),
+      (x) => !x.startsWith("wcag") && !x.startsWith("aria"),
     )
   )
     continue;

--- a/src/rules/empty-heading.ts
+++ b/src/rules/empty-heading.ts
@@ -1,9 +1,50 @@
 import { AccessibilityError } from "../scanner";
-import { querySelectorAll, hasAccessibleText } from "../utils";
+import { querySelectorAll, labelledByIsValid } from "../utils";
 
 const id = "empty-heading";
 const text = "Headings must have discernible text";
 const url = `https://dequeuniversity.com/rules/axe/4.11/${id}`;
+
+// Walk a subtree producing a heading's "name from content" per the
+// accessible name computation: text nodes contribute their text, descendant
+// imgs contribute their `alt`, `aria-hidden="true"` subtrees are skipped,
+// and `role="presentation"`/`role="none"` elements contribute their content
+// but no element-specific name (e.g. an img's alt is dropped).
+function nameFromContent(el: Element): string {
+  let name = "";
+  for (const child of el.childNodes) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      name += child.textContent ?? "";
+      continue;
+    }
+    if (child.nodeType !== Node.ELEMENT_NODE) continue;
+    const childEl = child as Element;
+    if (childEl.getAttribute("aria-hidden") === "true") continue;
+
+    const role = childEl.getAttribute("role");
+    const isPresentational = role === "presentation" || role === "none";
+
+    if (childEl.tagName === "IMG" && !isPresentational) {
+      name += childEl.getAttribute("alt") ?? "";
+      continue;
+    }
+
+    name += nameFromContent(childEl);
+  }
+  return name;
+}
+
+function hasAccessibleHeadingName(el: Element): boolean {
+  if (el.hasAttribute("aria-labelledby")) {
+    return labelledByIsValid(el);
+  }
+  if (el.hasAttribute("aria-label")) {
+    return el.getAttribute("aria-label")!.trim() !== "";
+  }
+  if (nameFromContent(el).trim() !== "") return true;
+  const title = el.getAttribute("title");
+  return title !== null && title.trim() !== "";
+}
 
 export default function (element: Element): AccessibilityError[] {
   const errors: AccessibilityError[] = [];
@@ -13,7 +54,7 @@ export default function (element: Element): AccessibilityError[] {
     elements.push(element);
   }
   for (const el of elements) {
-    if (!hasAccessibleText(el)) {
+    if (!hasAccessibleHeadingName(el)) {
       errors.push({ id, element: el, text, url });
     }
   }

--- a/tests/act/tests/ffd0e9/0ac909cfd0a0200a97cca3107011fe1e1c08ecc8.ts
+++ b/tests/act/tests/ffd0e9/0ac909cfd0a0200a97cca3107011fe1e1c08ecc8.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[ffd0e9]Heading has non-empty accessible name", function () {
+  it("Passed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/ffd0e9/0ac909cfd0a0200a97cca3107011fe1e1c08ecc8.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 1</title>
+</head>
+<body>
+	<h1>ACT rules</h1>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/empty-heading"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/ffd0e9/0bf7d49ddf99066b816fe42e5cd827a15c7ad24d.ts
+++ b/tests/act/tests/ffd0e9/0bf7d49ddf99066b816fe42e5cd827a15c7ad24d.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[ffd0e9]Heading has non-empty accessible name", function () {
+  it("Failed Example 8 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/ffd0e9/0bf7d49ddf99066b816fe42e5cd827a15c7ad24d.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 8</title>
+</head>
+<body>
+	<h1 aria-label="" role="none"><span aria-hidden="true">ACT rules</span></h1>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/empty-heading"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/ffd0e9/5655cd127e7f8e1e9306b1858e2bc018392564b3.ts
+++ b/tests/act/tests/ffd0e9/5655cd127e7f8e1e9306b1858e2bc018392564b3.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[ffd0e9]Heading has non-empty accessible name", function () {
+  it("Failed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/ffd0e9/5655cd127e7f8e1e9306b1858e2bc018392564b3.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 1</title>
+</head>
+<body>
+	<h1><img src="/WAI/content-assets/wcag-act-rules/test-assets/shared/act-logo.png" alt="" /></h1>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/empty-heading"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/ffd0e9/623ac29716a01c2888ff9bc94bdbca9fd18296e1.ts
+++ b/tests/act/tests/ffd0e9/623ac29716a01c2888ff9bc94bdbca9fd18296e1.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[ffd0e9]Heading has non-empty accessible name", function () {
+  it("Failed Example 4 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/ffd0e9/623ac29716a01c2888ff9bc94bdbca9fd18296e1.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 4</title>
+</head>
+<body>
+	<h1><img src="/WAI/content-assets/wcag-act-rules/test-assets/shared/act-logo.png" alt="ACT rules" role="presentation" /></h1>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/empty-heading"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/ffd0e9/73050f33875bf32ae13733b96d0408b6b255e4a1.ts
+++ b/tests/act/tests/ffd0e9/73050f33875bf32ae13733b96d0408b6b255e4a1.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[ffd0e9]Heading has non-empty accessible name", function () {
+  it("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/ffd0e9/73050f33875bf32ae13733b96d0408b6b255e4a1.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 2</title>
+</head>
+<body>
+	<div role="heading" aria-level="1">ACT rules</div>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/empty-heading"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/ffd0e9/7c593a17ea2affd0b822f3e66b9e804f00529f0a.ts
+++ b/tests/act/tests/ffd0e9/7c593a17ea2affd0b822f3e66b9e804f00529f0a.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[ffd0e9]Heading has non-empty accessible name", function () {
+  it("Failed Example 7 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/ffd0e9/7c593a17ea2affd0b822f3e66b9e804f00529f0a.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 7</title>
+</head>
+<body>
+	<div role="heading" aria-level="1" style="border-style: solid"></div>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/empty-heading"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/ffd0e9/937a207d1054feada41871a2fa88257d1345bda4.ts
+++ b/tests/act/tests/ffd0e9/937a207d1054feada41871a2fa88257d1345bda4.ts
@@ -1,0 +1,28 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[ffd0e9]Heading has non-empty accessible name", function () {
+  it("Failed Example 6 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/ffd0e9/937a207d1054feada41871a2fa88257d1345bda4.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 6</title>
+</head>
+<body>
+	<span>Hello</span>
+	<h1></h1>
+	<span>World!</span>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/empty-heading"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/ffd0e9/bd1a62830ac1d9800078f26866da433781f9c85f.ts
+++ b/tests/act/tests/ffd0e9/bd1a62830ac1d9800078f26866da433781f9c85f.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[ffd0e9]Heading has non-empty accessible name", function () {
+  it("Passed Example 4 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/ffd0e9/bd1a62830ac1d9800078f26866da433781f9c85f.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 4</title>
+</head>
+<body>
+	<h1><img src="/WAI/content-assets/wcag-act-rules/test-assets/shared/act-logo.png" alt="ACT rules" /></h1>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/empty-heading"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/ffd0e9/c01940d4367bd13fca88f88c10c2a97bc243606d.ts
+++ b/tests/act/tests/ffd0e9/c01940d4367bd13fca88f88c10c2a97bc243606d.ts
@@ -1,0 +1,27 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[ffd0e9]Heading has non-empty accessible name", function () {
+  it("Failed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/ffd0e9/c01940d4367bd13fca88f88c10c2a97bc243606d.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 3</title>
+</head>
+<body>
+	<span id="h-name" hidden></span>
+	<h1 aria-labelledby="h-name"><span aria-hidden="true">ACT rules</span></h1>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/empty-heading"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/ffd0e9/cc22b9130f7d1963b38975576e11d035ef44e13c.ts
+++ b/tests/act/tests/ffd0e9/cc22b9130f7d1963b38975576e11d035ef44e13c.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[ffd0e9]Heading has non-empty accessible name", function () {
+  it("Failed Example 5 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/ffd0e9/cc22b9130f7d1963b38975576e11d035ef44e13c.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 5</title>
+</head>
+<body>
+	<h1><br /></h1>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/empty-heading"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/ffd0e9/d37f6335303b2a57c3f81d1d602287952f27ab8e.ts
+++ b/tests/act/tests/ffd0e9/d37f6335303b2a57c3f81d1d602287952f27ab8e.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[ffd0e9]Heading has non-empty accessible name", function () {
+  it("Failed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/ffd0e9/d37f6335303b2a57c3f81d1d602287952f27ab8e.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 2</title>
+</head>
+<body>
+	<h1 aria-label=""><span aria-hidden="true">ACT rules</span></h1>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/empty-heading"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/ffd0e9/e62fd17ec8a90b871727e871d5136fc785ca13ad.ts
+++ b/tests/act/tests/ffd0e9/e62fd17ec8a90b871727e871d5136fc785ca13ad.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[ffd0e9]Heading has non-empty accessible name", function () {
+  it("Passed Example 5 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/ffd0e9/e62fd17ec8a90b871727e871d5136fc785ca13ad.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 5</title>
+</head>
+<body>
+	<h1 style="position: absolute; top: -9999px">ACT rules</h1>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/empty-heading"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/ffd0e9/f55422cabb0efc3a6491733c849306bfea1b1c9c.ts
+++ b/tests/act/tests/ffd0e9/f55422cabb0efc3a6491733c849306bfea1b1c9c.ts
@@ -1,0 +1,27 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[ffd0e9]Heading has non-empty accessible name", function () {
+  it("Passed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/ffd0e9/f55422cabb0efc3a6491733c849306bfea1b1c9c.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 3</title>
+</head>
+<body>
+	<span id="h-name" hidden>ACT rules</span>
+	<h1 aria-labelledby="h-name">Learn about ACT rules</h1>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/empty-heading"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});


### PR DESCRIPTION
## Summary
Two things kept `ffd0e9` (Heading has non-empty accessible name) out of the generated ACT tests despite the scanner already having an `empty-heading` mapping:

1. **Generator filter was too narrow.** The generator skipped any testcase whose `ruleAccessibilityRequirements` had no `wcag*` key, but ffd0e9's testcases reference `aria12:namecalculation` (ARIA 1.2 §5.2.8 — Accessible Name Calculation), which corresponds to WCAG SC 4.1.2 (Name, Role, Value). Accept any `aria*` key alongside `wcag*`.
2. **Rule missed name-from-content for img descendants.** `<h1><img alt="ACT rules"></h1>` has empty `textContent`, but the alt contributes the heading's accessible name. Compute a local subtree name that includes descendant `<img alt>`, skips `aria-hidden="true"` subtrees, and ignores alt text on `role="presentation"`/`role="none"` images (those are removed from the a11y tree).

ffd0e9: 0 → 13/13 (zero → consistent).

Refs #413.

## Test plan
- [x] `npm test` (412 files passing)
- [x] `npm run build:readme`

🤖 Generated with [Claude Code](https://claude.com/claude-code)