### PR TITLE
Move 46ca7f ACT rule to consistently implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Implementation status against the [ACT Rules Community Group](https://act-rules.
 
 The W3C [ACT implementations report](https://www.w3.org/WAI/standards-guidelines/act/implementations/) only counts a rule as "consistently implemented" when the implementation passes every published ACT test case for it. By that measure:
 
-- **19** ACT rules pass every generated test case (W3C "consistent implementation" criterion).
+- **20** ACT rules pass every generated test case (W3C "consistent implementation" criterion).
 - **14** more rules pass at least one test case but not all.
 - **53 / 88** ACT rules have some scanner implementation, even if untested.
-- **287 / 843** ACT test cases (34%) are exercised against the scanner.
+- **296 / 843** ACT test cases (35%) are exercised against the scanner.
 
 | Implemented | ACT Rule                                                                                                                                         | WCAG                | axe-core rule(s)                                                          | Test cases |
 | :---------- | :----------------------------------------------------------------------------------------------------------------------------------------------- | :------------------ | :------------------------------------------------------------------------ | :--------- |
@@ -39,7 +39,7 @@ The W3C [ACT implementations report](https://www.w3.org/WAI/standards-guidelines
 | ✅          | [ye5d6e](https://act-rules.github.io/rules/ye5d6e) — Document has an instrument to move focus to non-repeated content                            | —                   | `bypass`                                                                  | 9 / 11     |
 | ✅          | [047fe0](https://act-rules.github.io/rules/047fe0) — Document has heading for non-repeated content                                               | —                   | `bypass`                                                                  | 10 / 13    |
 | ❌          | [oj04fd](https://act-rules.github.io/rules/oj04fd) — Element in sequential focus order has visible focus                                         | 2.4.7               | —                                                                         | 0 / 6      |
-| ✅          | [46ca7f](https://act-rules.github.io/rules/46ca7f) — Element marked as decorative is not exposed                                                 | —                   | `presentation-role-conflict`                                              | 0 / 9      |
+| ✅          | [46ca7f](https://act-rules.github.io/rules/46ca7f) — Element marked as decorative is not exposed                                                 | —                   | `presentation-role-conflict`                                              | 9 / 9      |
 | ✅          | [6cfa84](https://act-rules.github.io/rules/6cfa84) — Element with aria-hidden has no content in sequential focus navigation                      | 4.1.2               | `aria-hidden-focus`                                                       | 11 / 12    |
 | ✅          | [de46e4](https://act-rules.github.io/rules/de46e4) — Element with lang attribute has valid language tag                                          | 3.1.2               | `valid-lang`                                                              | 14 / 14    |
 | ✅          | [307n5z](https://act-rules.github.io/rules/307n5z) — Element with presentational children has no focusable content                               | 4.1.2               | `nested-interactive`                                                      | 0 / 9      |

--- a/generate-act-tests.js
+++ b/generate-act-tests.js
@@ -51,9 +51,12 @@ function ruleIdToIdent(ruleId) {
   return ruleId.replace(/-([a-z0-9])/g, (_, c) => c.toUpperCase());
 }
 
-const applicableRules = testcases.filter(
-  (rule) => rule.ruleAccessibilityRequirements,
-);
+// Some ACT rules ship with `ruleAccessibilityRequirements: null` (e.g.
+// 46ca7f, b40fd1) — they encode correctness of ARIA/landmark usage rather
+// than mapping directly to a WCAG SC. Keep them in the candidate set so
+// rules with a scanner mapping still get exercised; the per-testcase filter
+// below is what gates on `wcag*`/`aria*` keys when requirements exist.
+const applicableRules = testcases;
 
 const testCasesThatRedirect = [
   "0ae68e88f61e1bc6cc56f7a4ae1bcf852d68cde2",
@@ -151,6 +154,13 @@ const rulesToIgnore = [
   // "3e12e1", // Block of repeated content is collapsible — enabled for bypass rule ACT tests
 
   // --- Not implemented - various other rules ---
+  "2eb176", // Audio element content has transcript - not implemented
+  "a1b64e", // Focusable element has no keyboard trap via standard navigation - not implemented
+  "ab4d13", // Video element content is media alternative for text - not implemented
+  "afb423", // Audio element content is media alternative for text - not implemented
+  "b40fd1", // Document has a landmark with non-repeated content - bypass impl doesn't cover landmarks
+  "ebe86a", // Focusable element has no keyboard trap via non-standard navigation - not implemented
+  "fd26cf", // Video element visual-only content is media alternative for text - not implemented
   "73f2c2", // Autocomplete attribute has valid value - not implemented in ACT test format
   "4b1c6c", // Iframe elements with identical accessible names have equivalent purpose - not implemented
   "b49b2e", // Heading is descriptive - not implemented, requires human judgment
@@ -307,7 +317,10 @@ for (const rule of applicableRules) {
 
   // Accept WCAG-mapped requirements and ARIA name-calculation requirements
   // (ARIA 1.2 §5.2.8 corresponds to WCAG SC 4.1.2 Name, Role, Value).
+  // Null requirements fall through (handled via `applicableRules` widening
+  // above); when present, accept WCAG- and ARIA-mapped keys.
   if (
+    ruleAccessibilityRequirements &&
     Object.keys(ruleAccessibilityRequirements).every(
       (x) => !x.startsWith("wcag") && !x.startsWith("aria"),
     )

--- a/src/rules/presentation-role-conflict.ts
+++ b/src/rules/presentation-role-conflict.ts
@@ -9,9 +9,14 @@ const url = `https://dequeuniversity.com/rules/axe/4.11/${id}`;
 const conflictAttrs = ["aria-label", "aria-labelledby", "aria-describedby"];
 const nativeFocusable = ["a[href]", "button", "input", "select", "textarea"];
 
+// `<img alt="">` is implicitly marked as decorative per ACT 46ca7f: an empty
+// alt removes the img from the accessibility tree the same way as
+// role="presentation"/"none". Surfacing it via aria-label/labelledby/
+// describedby (or making it focusable) creates the same exposure conflict.
+const selector = '[role="none"], [role="presentation"], img[alt=""]';
+
 export default function (element: Element): AccessibilityError[] {
   const errors: AccessibilityError[] = [];
-  const selector = '[role="none"], [role="presentation"]';
   const elements = querySelectorAll(selector, element);
   if (element.matches(selector)) elements.push(element);
 

--- a/tests/act/tests/46ca7f/6687821a71b53e0e1764e895900a6bad46412b5c.ts
+++ b/tests/act/tests/46ca7f/6687821a71b53e0e1764e895900a6bad46412b5c.ts
@@ -1,0 +1,28 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[46ca7f]Element marked as decorative is not exposed", function () {
+  it("Passed Example 6 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/46ca7f/6687821a71b53e0e1764e895900a6bad46412b5c.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 6</title>
+</head>
+<body>
+	<svg role="none">
+		<circle cx="50" cy="50" r="40" fill="yellow"></circle>
+	</svg>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/presentation-role-conflict"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/46ca7f/6f8e6014c133635fecac02e1087a666c5014ae5f.ts
+++ b/tests/act/tests/46ca7f/6f8e6014c133635fecac02e1087a666c5014ae5f.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[46ca7f]Element marked as decorative is not exposed", function () {
+  it("Passed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/46ca7f/6f8e6014c133635fecac02e1087a666c5014ae5f.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 3</title>
+</head>
+<body>
+	<img src="/WAI/content-assets/wcag-act-rules/test-assets/shared/w3c-logo.png" alt="" hidden />
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/presentation-role-conflict"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/46ca7f/96c1f58088f1e32c965f38ddc50d4b88f6a0f022.ts
+++ b/tests/act/tests/46ca7f/96c1f58088f1e32c965f38ddc50d4b88f6a0f022.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[46ca7f]Element marked as decorative is not exposed", function () {
+  it("Failed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/46ca7f/96c1f58088f1e32c965f38ddc50d4b88f6a0f022.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 2</title>
+</head>
+<body>
+	<img src="/WAI/content-assets/wcag-act-rules/test-assets/shared/w3c-logo.png" alt="" aria-labelledby="label" /> <span hidden id="label">W3C logo</span>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/presentation-role-conflict"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/46ca7f/9c51e8f0568ab3401375114dd0eded2eddfe231a.ts
+++ b/tests/act/tests/46ca7f/9c51e8f0568ab3401375114dd0eded2eddfe231a.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[46ca7f]Element marked as decorative is not exposed", function () {
+  it("Passed Example 5 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/46ca7f/9c51e8f0568ab3401375114dd0eded2eddfe231a.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 5</title>
+</head>
+<body>
+	<img src="/WAI/content-assets/wcag-act-rules/test-assets/shared/w3c-logo.png" role="presentation" alt="W3C logo" />
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/presentation-role-conflict"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/46ca7f/b40e6ce081099b8bf0f76a43f4c27f12df342ddd.ts
+++ b/tests/act/tests/46ca7f/b40e6ce081099b8bf0f76a43f4c27f12df342ddd.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[46ca7f]Element marked as decorative is not exposed", function () {
+  it("Passed Example 2 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/46ca7f/b40e6ce081099b8bf0f76a43f4c27f12df342ddd.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 2</title>
+</head>
+<body>
+	<img src="/WAI/content-assets/wcag-act-rules/test-assets/shared/w3c-logo.png" alt="" aria-hidden="true" />
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/presentation-role-conflict"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/46ca7f/b4329d21bd80d961408bf066a70998417234f200.ts
+++ b/tests/act/tests/46ca7f/b4329d21bd80d961408bf066a70998417234f200.ts
@@ -1,0 +1,28 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[46ca7f]Element marked as decorative is not exposed", function () {
+  it("Failed Example 3 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/46ca7f/b4329d21bd80d961408bf066a70998417234f200.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 3</title>
+</head>
+<body>
+	<svg role="none" aria-label="Yellow circle">
+		<circle cx="50" cy="50" r="40" fill="yellow"></circle>
+	</svg>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/presentation-role-conflict"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/46ca7f/e136a03c52c01c1b190c7372d83463f3c6502de9.ts
+++ b/tests/act/tests/46ca7f/e136a03c52c01c1b190c7372d83463f3c6502de9.ts
@@ -1,0 +1,28 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[46ca7f]Element marked as decorative is not exposed", function () {
+  it("Failed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/46ca7f/e136a03c52c01c1b190c7372d83463f3c6502de9.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Failed Example 1</title>
+</head>
+<body>
+	<nav role="presentation" aria-label="global">
+		<a href="https://act-rules.github.io/" aria-label="ACT rules">ACT rules</a>
+	</nav>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    expect(results).to.not.be.empty;
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/presentation-role-conflict"];
+    expect(results.some(r => expectedUrls.includes(r.url))).to.be.true;
+  });
+});

--- a/tests/act/tests/46ca7f/e5b8fa7ab66409e7b52b335a8b6aebe11fd78635.ts
+++ b/tests/act/tests/46ca7f/e5b8fa7ab66409e7b52b335a8b6aebe11fd78635.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[46ca7f]Element marked as decorative is not exposed", function () {
+  it("Passed Example 1 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/46ca7f/e5b8fa7ab66409e7b52b335a8b6aebe11fd78635.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 1</title>
+</head>
+<body>
+	<img src="/WAI/content-assets/wcag-act-rules/test-assets/shared/w3c-logo.png" alt="" />
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/presentation-role-conflict"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});

--- a/tests/act/tests/46ca7f/eb5983ff8bb0f85c891d48f96106337446797d8f.ts
+++ b/tests/act/tests/46ca7f/eb5983ff8bb0f85c891d48f96106337446797d8f.ts
@@ -1,0 +1,28 @@
+import { expect } from "@open-wc/testing";
+import { scan } from "../../../../src/scanner";
+
+const parser = new DOMParser();
+
+describe("[46ca7f]Element marked as decorative is not exposed", function () {
+  it("Passed Example 4 (https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/46ca7f/eb5983ff8bb0f85c891d48f96106337446797d8f.html)", async () => {
+    const document = parser.parseFromString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Passed Example 4</title>
+</head>
+<body>
+	<nav role="presentation">
+		<a href="https://act-rules.github.io/" aria-label="ACT rules">ACT rules</a>
+	</nav>
+</body>
+</html>`, 'text/html');
+
+    const results = (await scan(document.body)).map(({ text, url }) => {
+      return { text, url };
+    });
+
+    const expectedUrls = ["https://dequeuniversity.com/rules/axe/4.11/presentation-role-conflict"];
+    const relevant = results.filter(r => expectedUrls.includes(r.url));
+    expect(relevant).to.be.empty;
+  });
+});


### PR DESCRIPTION
## Summary
Three things kept `46ca7f` (Element marked as decorative is not exposed) out of the generated ACT tests despite the scanner having a `presentation-role-conflict` mapping:

1. **Generator excluded testcases with null `ruleAccessibilityRequirements`.** 46ca7f and a handful of other ACT rules (`b40fd1`, `a1b64e`, `afb423`, `2eb176`, `ebe86a`, `ab4d13`, `fd26cf`) omit requirements because they encode ARIA/landmark correctness rather than mapping to a specific WCAG SC. Let those through; the per-WCAG-key gate still applies when requirements exist.
2. **Rule selector was too narrow.** It only matched `[role="none"]`/`[role="presentation"]`, but ACT also treats `<img alt="">` as implicitly marked decorative — a non-empty `aria-label`/`aria-labelledby`/`aria-describedby` (or making the img focusable) creates the same exposure conflict. Added `img[alt=""]` to the selector.
3. **Companion null-requirements rules aren't actually implemented yet.** Once the filter widened, several rules that were silently excluded started surfacing failures. Add them to `rulesToIgnore` with explicit comments — documenting the gap rather than hiding it.

46ca7f: 0 → 9/9 (zero → consistent).

Refs #413.

## Test plan
- [x] `npm test`
- [x] `npm run build:readme`

🤖 Generated with [Claude Code](https://claude.com/claude-code)